### PR TITLE
Translation fixes + Explicitly Defining Sectional Link ID Attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ title: 主页
 description: 欢迎访问Moonbeam资料库，Moonbeam是Polkadot上兼容以太坊的智能合约平行链。
 ---
 
-# 欢迎访问Moonbeam
+# 欢迎访问Moonbeam 
 
 ![Main Page Banner Image](/images/main-banner.png)
 
@@ -15,7 +15,7 @@ Moonbeam是同时兼容波卡（Polkadot）生态与以太坊（Ethereum）生�
 
 ---
 
-## 什么是Moonbeam？
+## 什么是Moonbeam？ {: #what-is-moonbeam }
 
 Moonbeam是开发者友好型区块链，可实现完全兼容EVM、Web3的API兼容以及将Moonbeam连接到现有的以太坊网络的网桥。开发者可借助Moonbeam，利用现有的以太坊开发者工具和网络，轻松实现跨链兼容。开发者只需基于自身开发成果稍作修改，即可轻松将现有的Solidity智能合约和DApp前端部署到Moonbeam。
 
@@ -23,16 +23,16 @@ Moonbeam还将成为波卡（Polkadot）网络的平行链。这意味着Moonbea
 
 ---
 
-## 如何参与Moonbeam？
+## 如何参与Moonbeam？ {: #how-to-get-started-with-moonbeam }
 
-### 网络
+### 网络 {: #networks }
 
 目前，任选以下一种方式，助您轻松参与Moonbeam构建：
 
  - 将您的Moonbeam实例构建为[独立节点](/getting-started/local-node/setting-up-a-node/)
  - [连接](/getting-started/moonbase/connect/)到[Moonbase Alpha TestNet](/networks/moonbase/) 
 
-### 钱包
+### 钱包 {: #wallets }
 
 目前，我们成功测试以下钱包可使用Moonbeam网络：
 
@@ -43,7 +43,7 @@ Moonbeam还将成为波卡（Polkadot）网络的平行链。这意味着Moonbea
 
 请注意，我们欢迎任何与以太坊定制网络兼容的钱包与Moonbeam兼容！
 
-### 开发工具
+### 开发工具 {: #tools }
 
 由于Moonbeam的以太坊兼容性，您可自由选择以下您了解并喜爱的开发工具：
 
@@ -59,7 +59,7 @@ Moonbeam还将成为波卡（Polkadot）网络的平行链。这意味着Moonbea
 
 有更好的以太坊工具推荐？[欢迎联系我们](https://discord.gg/PfpUATX)
 
-### 预言机
+### 预言机 {: #oracles }
 
 我们提供多个预言机选项，实现智能合约数据喂价：
 
@@ -67,7 +67,7 @@ Moonbeam还将成为波卡（Polkadot）网络的平行链。这意味着Moonbea
  - [Band Protocol](/integrations/oracles/band-protocol/)
  - [Razor Network](/integrations/oracles/razor-network/)
 
-### 桥服务
+### 桥服务 {: #bridges }
 
 目前，我们可提供功能齐全的桥服务，实现连接以太坊Rinkeby/Kovan测试网和Moonbase Alpha测试网：
 
@@ -75,7 +75,7 @@ Moonbeam还将成为波卡（Polkadot）网络的平行链。这意味着Moonbea
 
 ---
 
-## 如何参与Moonbeam社区互动
+## 如何参与Moonbeam社区互动 {: #how-to-engage-with-the-moonbeam-community }
 
 ### :fontawesome-brands-discord:  Discord  
 
@@ -101,6 +101,6 @@ Moonbeam还将成为波卡（Polkadot）网络的平行链。这意味着Moonbea
 
 订阅 [Moonbeam 电子月报](https://moonbeam.network/newsletter/)，获取每月Moonbeam进展总结。
 
-## 关于Moonbeam资料库
+## 关于Moonbeam资料库 {: #about-this-site }
 
 本资料库生成自[mkdocs](https://www.mkdocs.org/)，所有内容均来源于moonbeam-docs，且可在 [on :fontawesome-brands-github: GitHub](https://github.com/PureStake/moonbeam-docs)同步找到。

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Moonbeam还将成为波卡（Polkadot）网络的平行链。这意味着Moonbea
 
 目前，任选以下一种方式，助您轻松参与Moonbeam构建：
 
- - 将您的Moonbeam实体构建为[独立节点](/getting-started/local-node/setting-up-a-node/)
+ - 将您的Moonbeam实例构建为[独立节点](/getting-started/local-node/setting-up-a-node/)
  - [连接](/getting-started/moonbase/connect/)到[Moonbase Alpha TestNet](/networks/moonbase/) 
 
 ### 钱包

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ description: 欢迎访问Moonbeam资料库，Moonbeam是Polkadot上兼容以太�
 
 ![Main Page Banner Image](/images/main-banner.png)
 
-Moonbeam是同时兼容波卡（Polkadot）生态与以太坊（Ethereum）生态的智能合约平行链。本网站为Moonbeam资料库，在这里，您可自由浏览关于开发人员，信息收集者，终端用户和其他Moonbeam网络节点的第一手资料。
+Moonbeam是同时兼容波卡（Polkadot）生态与以太坊（Ethereum）生态的智能合约平行链。本网站为Moonbeam资料库，在这里，无论您是开发人员，信息收集者，或终端用户都可自由浏览关于Moonbeam网络平台的第一手资料。
 
 本网站信息将随着Moonbeam社区的发展而实时更新。 
 

--- a/getting-started/local-node/setting-up-a-node.md
+++ b/getting-started/local-node/setting-up-a-node.md
@@ -8,21 +8,21 @@ description: 此教程将帮助您学习如何设置您的第一个Moonbeam节�
 <style>.embed-container { position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; max-width: 100%; } .embed-container iframe, .embed-container object, .embed-container embed { position: absolute; top: 0; left: 0; width: 100%; height: 100%; }</style><div class='embed-container'><iframe src='https://www.youtube.com/embed/p_0OAHSlHNM' frameborder='0' allowfullscreen></iframe></div>
 <style>.caption { font-family: Open Sans, sans-serif; font-size: 0.9em; color: rgba(170, 170, 170, 1); font-style: italic; letter-spacing: 0px; position: relative;}</style><div class='caption'>You can find all of the relevant code for this tutorial on the <a href="{{ config.site_url }}resources/code-snippets/">code snippets page</a></div>
 
-## 概览
+## 概览 {: #introduction }
 
 本教程将指导您如何设置一个独立的Moonbeam本地节点，并测试Moonbeam与以太坊之间的兼容性与功能性。
 
 !!! 注意事项 
-    本教程使用[Moonbase Alpha](https://github.com/PureStake/moonbeam)的tutorial-v7标签建立。为实现与以太坊的全面兼容，基于Substrate的Moonbeam平台和[Frontier](https://github.com/paritytech/frontier)组件正处于积极开发阶段。本教程示例基于Ubuntu 18.04的环境，用户需根据其所使用的MacOS和Windows版本进行微调。
+    本教程使用[Moonbase Alpha](https://github.com/PureStake/moonbeam)的tutorial-v7标签建立。为实现与以太坊的全面兼容，基于Substrate的Moonbeam平台和[Frontier](https://github.com/paritytech/frontier)组件正处于积极开发阶段。
     --8<-- 'text/common/assumes-mac-or-ubuntu-env.md'
 
 Moonbeam开发节点是基于您的个人开发环境，在Moonbeam上构建和测试应用程序，相当于以太坊开发人员使用的Ganache。Moonbeam助您快速轻松地上手，无需承担中继链的成本。您可以使用 `--sealing` 选项，立即启动节点来创建区块，或者在交易完成后的自定义时间段创建区块。默认情况下，收到交易意味着一个区块即被创建，类似于Ganache的instamine功能。
 
-如您参考本教程指示操作，您可顺利连接至默认的Polkadot JS GUI的Moonbeam节点，同时获得10个 [预注资的账户](/getting-started/local-node/setting-up-a-node/#pre-funded-development-accounts)，该节点可在本地环境运行。
+如您参考本教程指示操作，您可顺利在本地环境运行Moonbeam开发节点，同时获得10个[预注资的账户](#prefunded-development-accounts)，并且可以使用Polkadot JS GUI与节点交互。
 
-另有两种方法助您运行Moonbeam节点：使用[Docker来执行预建二进制](/getting-started/local-node/setting-up-a-node/#getting-started-with-docker)，或[在本地编译二进制](/getting-started/local-node/setting-up-a-node/#getting-started-with-the-binary-file)设置开发节点。点击此处便可安装[Docker](https://docs.docker.com/get-docker/)。Docker更为快速便捷，您无需安装Substrate，所有辅助项，且无需构建节点即可运行。另一方面，如果您仍希望体验构建节点进程，则需要大约30分钟或更长时间完成，具体情况取决于您的硬件设备。
+目前有两种方式在本地运行Moonbeam节点：使用[Docker来执行预建二进制](#getting-started-with-docker)，或[在本地编译二进制](#getting-started-with-the-binary-file)设置开发节点。点击此处便可安装[Docker](https://docs.docker.com/get-docker/)。Docker更为快速便捷，您无需安装Substrate，所有辅助项，且无需构建节点即可运行。另一方面，如果您仍希望体验构建节点进程，则需要大约30分钟或更长时间完成，具体情况取决于您的硬件设备。
 
-## 使用Docker进行安装与设置
+## 使用Docker进行安装与设置 {: #getting-started-with-docker }
 
 使用Docker可让您可以在几秒钟内启动节点。安装Docker后，您可执行下列指令来下载相关图像：
 
@@ -54,7 +54,7 @@ docker pull purestake/moonbeam:{{ networks.development.build_tag }}
 
 ![Docker - output shows blocks being produced](/images/setting-up-a-node/setting-up-node-2.png)
 
-您可点击[一般标识及选项](/getting-started/local-node/setting-up-a-node/#common-flags-and-options)来查阅更多实例的标识及选项。如果要查看所有标识、选项和子命令的完整列表，请通过运行以下命令打开帮助菜单：
+您可点击[常用标识及选项](#common-commands-flags-and-options)来查阅更多实例的标识及选项。如果要查看所有标识、选项和子命令的完整列表，请通过运行以下命令打开帮助菜单：
 
 ```
 docker run --rm --name {{ networks.development.container_name }} \
@@ -62,8 +62,8 @@ purestake/moonbeam \
 --help
 ```
 
-如果您已经使用Docker来启动节点，则可以跳过下一部分的教程，直接进入[设置Moonbeam节点并连接至Polkadot JS GUI](/getting-started/local-node/setting-up-a-node/#connecting-polkadot-js-apps-to-a-local-moonbeam-node).
-## 安装与预设  
+如果您已经使用Docker来启动节点，则可以跳过下一部分的教程，直接进入[设置Moonbeam节点并连接至Polkadot JS GUI](#connecting-polkadot-js-apps-to-a-local-moonbeam-node).
+## 使用源码编译，安装与设置  {: #getting-started-with-the-binary-file }
 
 第一步，我们通过下列链接来克隆一个Moonbeam Repo的特定标签：
 
@@ -112,14 +112,14 @@ cd moonbeam
 
 ![Output shows blocks being produced](/images/setting-up-a-node/setting-up-node-4.png)
 
-您可点击[一般标识及选项](/getting-started/local-node/setting-up-a-node/#common-flags-and-options)来查阅更多用于实例的标识及选项。如果要查看所有标识、选项和子命令的完整列表，请通过运行以下命令打开帮助菜单：
+您可点击[常用标识及选项](#common-commands-flags-and-options)来查阅更多用于实例的标识及选项。如果要查看所有标识、选项和子命令的完整列表，请通过运行以下命令打开帮助菜单：
 
 ```
 ./target/release/moonbeam --help
 ```
-## 如何将Polkadot JS Apps 连接至本地Moonbeam节点
+## 如何将Polkadot JS Apps 连接至本地Moonbeam节点 {: #connecting-polkadot-js-apps-to-a-local-moonbeam-node :}
 
-发展节点是Substrate-based的节点，您可使用标准的Substrate工具来与之交互。两个可使用的RPC终端是：
+开发节点是基于Substrate框架的节点，您可使用标准的Substrate工具来与之交互。两个可使用的RPC终端是：
 
  - HTTP: `http://127.0.0.1:9933`
  - WS: `ws://127.0.0.1:9944` 
@@ -136,15 +136,15 @@ cd moonbeam
 
 ![Select Local Node](/images/setting-up-a-node/setting-up-node-7.png)
 
-## 如何查询账户状态
+## 如何查询账户状态 {: #querying-account-state }
 
-随着[Moonbase Alpha v3](https://moonbeam.network/announcements/moonbeam-network-upgrades-account-structure-to-match-ethereum/)的发布，Moonbeam可支持在单一账户的模式下运行，该模式为以太坊的H160并且已被Polkadot JS Apps支持。如果您想查看账户上的余额，您可直接将您的账户汇入至Accounts。了解更多，请参考[统一账户](/learn/unified-accounts/)页面。
+随着[Moonbase Alpha v3](https://moonbeam.network/announcements/moonbeam-network-upgrades-account-structure-to-match-ethereum/)的发布，Moonbeam可支持在统一账户模式下运行，该模式支持以太坊的H160账户格式并且已与Polkadot JS Apps兼容。如果您想查看账户上的余额，您可直接将您的账户汇入至Accounts。了解更多，请参考[统一账户](/learn/unified-accounts/)页面。
 
 您也可以利用Moonbeam完整的以太坊RPC功能，使用[MetaMask](/getting-started/local-node/using-metamask/)查询账户的余额。除此之外，您还可以利用其他的开发工具，如[Remix](/getting-started/local-node/using-remix/)和[Truffle](/getting-started/local-node/using-truffle/) 等等。
 
-## 一般命令、标识及选项
+## 常用命令、标识及选项 {: #common-commands-flags-and-options }
 
-### 清除数据
+### 清除数据 {: #purging-the-chain }
 
 通过二进制文件运行节点时，数据存储在本地目录中，该目录通常位于`~/.local/shared/moonbeam/chains/development/db`。如果要启动该节点的新实例，您可以删除该文件夹的内容，或者在`moonbeam`文件夹中运行以下命令：
 
@@ -155,7 +155,7 @@ cd moonbeam
 这将删除数据文件夹，请注意，所有链数据均已丢失。
 
 如果您使用Docker，则数据文件夹与Docker容器本身关联。
-### 节点标识
+### 节点标识 {: #node-flags }
 
 标识不带参数。 要使用标识，请将其添加到命令末尾。例如：
 
@@ -169,7 +169,7 @@ cd moonbeam
 - `--rpc-external`: 监听所有RPC接口
 - `--ws-external`: 监听所有Websocket接口
 
-### 节点选项
+### 节点选项 {: #node-options }
 
 选项接受选项右侧的参数。例如：
 
@@ -184,7 +184,7 @@ cd moonbeam
 
 如需标志和选项的完整列表，请在命令末尾添加 `--help` 来启动Moonbeam开发节点。
 
-## 高级标志和选项
+## 高级标志和选项 {: #advanced-flags-and-options }
 
 --8<-- 'text/setting-up-node/advanced-flags.md'
 
@@ -194,7 +194,7 @@ cd moonbeam
 ./target/release/moonbeam --dev --execution=Native --ethapi=debug,trace
 ```
 
-## 预注资开发账户
+## 预注资开发账户 {: #prefunded-development-accounts }
 
 您的Moonbeam开发节点带有十个预注资的开发帐户。这些地址源自于Substrate的规范开发助记符：
 

--- a/overview/vision-features.md
+++ b/overview/vision-features.md
@@ -11,34 +11,34 @@ description: Moonbeam旨在实现多链未来，解决跨链互操作性挑战�
 
 Moonbeam的跨链集成功能是通过成为Polkadot网络上的[平行链](/resources/glossary/#parachains)实现。[Polkadot网络](/resources/glossary/#polkadot)可提供集成和连接设施，链接Polkadot网络和非Polkadot生态链的平行链，例如通过桥接功能链接以太坊和比特币。
 
-## 谁会使用Moonbeam
+## 谁会使用Moonbeam {: #who-benefits-from-moonbeam }
 
 Moonbeam的跨链功能可让三类用户受益：
 
-### 现有的基于以太坊开发的项目
+### 现有的基于以太坊开发的项目 {: #existing-ethereum-based-projects }
 
 Moonbeam可解决以太坊面临的成本问题和可扩展性挑战：
 
- - 开发者只需微调项目成果，便可将现有的项目从以太坊Layer 1扩展到以太坊Layer 2。 
+ - 开发者只需微调项目成果，便可将现有的项目从以太坊Layer 1迁移至Moonbeam。
  - 应用程序可以同时在以太坊和Moonbeam上运行。 
  - 拓展Polkadot网络和其他Polkadot生态区块链的商业边界。  
 
-### Polkadot生态内的项目
+### Polkadot生态内的项目 {: #polkadot-ecosystem-projects }
 
 需要智能合约功能的项目可以通过Moonbeam实现： 
 
- - 增加其现有的平行链和平行线程  
+ - 辅助其现有的平行链和平行线程 
  - 新增所需但还未包含在主[Polkadot中继链](/resources/glossary/#relay-chain)上的功能。例如，创建用于团队进行项目众筹的场所，进行锁仓空投并处理比基本的[Substrate](/resources/glossary/#substrate)功能所提供的其他更为复杂的交易。  
  - 使用最佳的以太坊开发工具。  
 
-### 新DApp的开发者
+### 新DApp的开发者 {: #developers-of-new-dapps }
 
 Moonbeam可帮助在Polkadot上进行开发的个人和团队实现：
 
- - 借助Polkadot平行链的专业化功能，实现用户和流通资产在多条链上相互共享。
+ - 借助Polkadot平行链的专用化功能，实现用户和流通资产在多条链上相互共享。
  - 通过Moonbeam的技术堆栈，让集成变得轻松自如，实现将Polkadot平行链功能以集合形式呈现给终端用户。在智能合约平台使用预构建的集成来实现组合服务是更高效的选择（通常情况），可超越通过自我执行集成来运行并构建完整的Substrate。 
 
-## 核心特性和功能
+## 核心特性和功能 {: #key-features-and-functionality }
 
 Moonbeam具有以下核心特性：  
 
@@ -46,7 +46,7 @@ Moonbeam具有以下核心特性：
  - **完整的EVM实现**，基于Solidity的智能合约能以最小调整和最优预期结果实现部署。
  - **Web3 RPC API**，用最少的调整实现DApp前端部署。以太坊项目可以简单地复制其DApp，并使用MetaMask、Truffle、Remix和其他基于以太坊的工具将其部署到Moonbeam。
  - **兼容Substrate生态系统工具**，包含区块浏览器，前端开发资源库和钱包，允许开发人员和用户可以使用正确的工具将其集成到其区块链中。
- - 通过Polkadot网络和代币桥接进行的**本机跨链集成**实现代币转移，状态可见以及实现以太坊和其他链之间的跨链信息传递。 
+ - 通过Polkadot网络和代币桥接进行的**原生跨链集成**实现代币转移，状态可见以及实现以太坊和其他链之间的跨链信息传递。 
  - **链上治理**允许利益相关者根据开发者和社区的需求，非常快速简便地开发基本协议
 
 强大的兼容性迎合当前市场需求。随着Polkadot网络的不断发展，Moonbeam可成为帮助Polkadot吸引智能合约开发者的重要力量。使用Substrate框架构建自己的区块链的作用非常强大，但是一系列的责任也会随之而来，例如学习如何构建一个Rust运行时，如何创建代币经济模型以及如何激励社区节点并推动社区发展。

--- a/overview/why-polkadot.md
+++ b/overview/why-polkadot.md
@@ -6,13 +6,13 @@ description: Moonbeam基于Substrate框架开发，是Polkadot生态的重要链
 
 经过深入研究后，我们使用[Substrate开发框架](/resources/glossary/#substrate)构建Moonbeam，并将Moonbeam作为[平行链](/resources/glossary/#parachains)部署至[Polkadot网络](/resources/glossary/#polkadot)。
 
-## Substrate区块链框架
+## Substrate区块链框架 {: #substrate-blockchain-framework }
 
 Substrate是开发Moonbeam的现有最优选择，它是功能强大的区块链开发框架。Moonbeam基于Substrate框架开发，可以物尽其用Substrate的各类功能，比如「开箱即用」功能等，从而省去从零开发的成本。协助Moonbeam实现包括点对点网络，共识机制，治理功能，EVM执行等板块的开发。
 
 总体来说，使用Substrate可有效提升Moonbeam的开发效率。Substrate可极大程度定制化，这是实现与以太坊兼容必不可少的优势。而且，对Rust的使用还能让我们在保障安全性的同时，最大限度地提高性能。
 
-## Polkadot网络及生态系统
+## Polkadot网络及生态系统 {: #polkadot-network-and-ecosystem }
 
 Polkadot网络生态与Moonbeam相辅相成。作为Polkadot上的平行链，Moonbeam将能直接与网络上的任何平行链和平行线程集成，并轻松实现代币转移。
 


### PR DESCRIPTION
The Table of Contents (TOC) extension for mkdocs generates sectional URL slugs based on the heading text, but does not work well with unicode characters and condenses all of them into a dash, so in the case of the translated Chinese pages, the extension was generating sectional links that look like #_1, #_2, which are also causing the internal links to break because a lot of them are still using the English header URLs.

This page on live has quite a few examples of the issue above: https://docs.moonbeam.network/cn/getting-started/local-node/setting-up-a-node/

Current fix is to use an annotation from the python attribute list extension (https://python-markdown.github.io/extensions/attr_list/) to explicitly define the sectional header URL's in Chinese language pages so they can be consistent with existing links, and also readable.

This PR only includes the first few pages, as the issue exists on all Chinese document pages, so will address it as I review the pages in batches.

Can explore in the future to see if there are better solutions, such as using a custom slugify function for mkdocs.