### PR TITLE
Port staking changes

### DIFF
--- a/learn/features/staking.md
+++ b/learn/features/staking.md
@@ -28,7 +28,7 @@ Moonbeam采用基于[波卡的权益证明（PoS）模型](https://wiki.polkadot
     - **单个委托人可委托的最大委托人数** —— 一个委托人可以委托{{ networks.moonriver.staking.max_del_per_del }}个不同的候选人
     - **绑定时长** —— 委托将会在下一个轮次生效（资金可随时提取）
     - **解绑时长** —— {{ networks.moonriver.delegator_timings.del_bond_less.rounds }}轮次
-    - **奖励发放** —— {{ networks.moonriver.delegator_timings.rewards_payouts.rounds }}个轮次后奖励会自动发放至余额账户
+    - **奖励发放延迟** —— {{ networks.moonriver.delegator_timings.rewards_payouts.rounds }}个轮次后奖励会自动发放至余额账户
     - **收集人佣金** —— 固定为年通胀（{{ networks.moonriver.total_annual_inflation }}%）的{{ networks.moonriver.staking.collator_reward_inflation }}%，与委托人奖励池无关
     - **委托人奖励池** —— 年通胀的{{ networks.moonriver.staking.delegator_reward_inflation }}%
     - **委托人奖励** —— 随时变化。总委托人奖励分配给所有的有效委托人，与质押总量相关（[查看更多](/staking/overview/#reward-distribution)）
@@ -44,7 +44,7 @@ Moonbeam采用基于[波卡的权益证明（PoS）模型](https://wiki.polkadot
     - **单个委托人可委托的最大委托人数** —— 一个委托人可以委托{{ networks.moonbase.staking.max_del_per_del }}个不同的候选人
     - **绑定时长** —— 委托将会在下一个轮次生效（资金可随时提取）
     - **解绑时长** —— {{ networks.moonbase.delegator_timings.del_bond_less.rounds }}轮次
-    - **奖励发放** —— {{ networks.moonbase.delegator_timings.rewards_payouts.rounds }}个轮次后奖励会自动发放至余额账户
+    - **奖励发放延迟** —— {{ networks.moonbase.delegator_timings.rewards_payouts.rounds }}个轮次后奖励会自动发放至余额账户
     - **收集人佣金** —— 固定为年通胀（{{ networks.moonriver.total_annual_inflation }}%）的{{ networks.moonbase.staking.collator_reward_inflation }}%，与委托人奖励池无关
     - **委托人奖励池** —— 年通胀的{{ networks.moonbase.staking.delegator_reward_inflation }}%
     - **委托人奖励** —— 随时变化。总委托人奖励分配给所有的有效委托人，与质押总量相关（[查看更多](/staking/overview/#reward-distribution)）
@@ -56,7 +56,9 @@ Moonbeam采用基于[波卡的权益证明（PoS）模型](https://wiki.polkadot
 
 ## 奖励分配 {: #reward-distribution } 
 
-收集人在每轮（{{ networks.moonbase.staking.round_blocks }}个区块）结束时收到前{{ networks.moonriver.delegator_timings.rewards_payouts.rounds }}轮的奖励。
+收集人和委托人奖励会在每个轮次的开始计算，奖励资格由[奖励发放延迟](#quick-reference)前的状态来计算。例如在Moonriver网络上，本轮次的奖励是按照{{ networks.moonriver.delegator_timings.rewards_payouts.rounds }}轮次前的状态来计算。
+
+计算出的奖励会以线性方式释放，每个区块释放一次，直到所有奖励都释放完毕。每一个区块会随机选择一个收集人以及其委托人来发送奖励。假设有{{ networks.moonriver.staking.max_candidates }}个收集人, 那么全部收集人以及委托人会在新一轮开始后的第{{ networks.moonriver.staking.max_candidates }}块区块前收到奖励。
 
 5%的年通胀的分配安排如下：
 

--- a/learn/platform/networks/moonbeam.md
+++ b/learn/platform/networks/moonbeam.md
@@ -49,7 +49,9 @@ Moonbeam完全启动后将拥有以下配置：
     | 收集人可获得的委托人数上限 |                             {{ networks.moonbeam.staking.max_del_per_can }}                             |
     | 委托人可委托的收集人数上限   |                             {{ networks.moonbeam.staking.max_del_per_del }}                             |
     |               轮次               | {{ networks.moonbeam.staking.round_blocks }}区块（{{ networks.moonbeam.staking.round_hours }}小时） |
-    |           解绑期           |                            {{ networks.moonbeam.delegator_timings.del_bond_less.rounds }}轮次                             |
+    |           委托生效期           |   委托在下一轮开始生效 （资金会马上绑定）  |
+    |           解绑期           |   {{ networks.moonbeam.delegator_timings.del_bond_less.rounds }}轮次  |
+
 
 _*阅读更多关于[Token面额](#token-denominations)_
 

--- a/learn/platform/networks/moonriver.md
+++ b/learn/platform/networks/moonriver.md
@@ -57,7 +57,9 @@ _更新至2021年12月13日_
 | 收集人可获得最高的提名人数 |       {{ networks.moonriver.staking.max_del_per_can }}       |
 | 提名人可提名的最高收集人数 |       {{ networks.moonriver.staking.max_del_per_del }}       |
 |            轮次            | {{ networks.moonriver.staking.round_blocks }}区块（{{ networks.moonriver.staking.round_hours }}小时） |
-|           解绑期           |   {{ networks.moonbeam.delegator_timings.del_bond_less.rounds }}轮次        |
+|           委托生效期           |   委托在下一轮开始生效 （资金会马上绑定）  |
+|           解绑期           |   {{ networks.moonriver.delegator_timings.del_bond_less.rounds }}轮次       |
+
 
 _*更多关于[代币面额](#token-denominations)_
 

--- a/node-operators/networks/collator.md
+++ b/node-operators/networks/collator.md
@@ -38,7 +38,6 @@ Moonbeam使用[Nimbus平行链共识框架](/learn/features/consensus/)，通过
 === "Moonriver"
     |    变量     |                           值                           |
     |:---------------:|:---------------------------------------------------------:|
-    |   绑定数量   | {{ networks.moonriver.staking.min_can_stk }} MOVR  |
     | 最小自质押量 |     {{ networks.moonriver.staking.min_can_stk }} MOVR     |
     | 最小总质押量 |     {{ networks.moonriver.staking.min_col_stk }} MOVR     |
     | 有效集上限 | {{ networks.moonriver.staking.max_candidates }} |
@@ -46,7 +45,6 @@ Moonbeam使用[Nimbus平行链共识框架](/learn/features/consensus/)，通过
 === "Moonbase Alpha"
     |    变量     |                          值                           |
     |:---------------:|:--------------------------------------------------------:|
-    |   绑定数量   |  {{ networks.moonbase.staking.min_can_stk }} DEV  |
     | 最小自质押量 |     {{ networks.moonbase.staking.min_can_stk }} DEV    |
     | 最小总质押量 |     {{ networks.moonbase.staking.min_col_stk }} DEV     |
     | 有效集上限 | {{ networks.moonbase.staking.max_candidates }} |

--- a/node-operators/networks/collator.md
+++ b/node-operators/networks/collator.md
@@ -33,19 +33,23 @@ Moonbeam使用[Nimbus平行链共识框架](/learn/features/consensus/)，通过
 
 ## 账户与质押要求 {: #accounts-and-staking-requirements }
 
-和波卡（Polkadot）验证人相似，收集人也需要创建账户。Moonbeam使用的是拥有私钥的H160账户或以太坊式账户。另外，需要拥有最低Token质押量才有资格成为候选人。只有一定数量的根据提名质押量排名靠前的收集人才会进入收集人有效集。
+和波卡（Polkadot）验证人相似，收集人也需要创建账户。Moonbeam使用的是拥有私钥的H160账户或以太坊式账户。另外，需要拥有高于最低自质押量(Self-bonded)才有资格成为候选人。只有一定数量的根据质押量和委托量排名靠前的收集人才会进入收集人有效集。
 
 === "Moonriver"
     |    变量     |                           值                           |
     |:---------------:|:---------------------------------------------------------:|
-    |   绑定数量   | {{ networks.moonriver.staking.min_can_stk }}枚MOVR  |
-    | 有效集上限 | {{ networks.moonriver.staking.max_candidates }}名收集人 |
+    |   绑定数量   | {{ networks.moonriver.staking.min_can_stk }} MOVR  |
+    | 最小自质押量 |     {{ networks.moonriver.staking.min_can_stk }} MOVR     |
+    | 最小总质押量 |     {{ networks.moonriver.staking.min_col_stk }} MOVR     |
+    | 有效集上限 | {{ networks.moonriver.staking.max_candidates }} |
 
 === "Moonbase Alpha"
     |    变量     |                          值                           |
     |:---------------:|:--------------------------------------------------------:|
-    |   绑定数量   |  {{ networks.moonbase.staking.min_can_stk }}枚DEV  |
-    | 有效集上限 | {{ networks.moonbase.staking.max_candidates }}名收集人 |
+    |   绑定数量   |  {{ networks.moonbase.staking.min_can_stk }} DEV  |
+    | 最小自质押量 |     {{ networks.moonbase.staking.min_can_stk }} DEV    |
+    | 最小总质押量 |     {{ networks.moonbase.staking.min_col_stk }} DEV     |
+    | 有效集上限 | {{ networks.moonbase.staking.max_candidates }} |
 
 ### Polkadot.js账户 {: #account-in-polkadotjs }
 
@@ -81,7 +85,7 @@ Moonbeam使用[Nimbus平行链共识框架](/learn/features/consensus/)，通过
     | 奖励发放（在本轮结束后） |    {{ networks.moonbase.delegator_timings.rewards_payouts.rounds }} rounds ({{ networks.moonbase.delegator_timings.rewards_payouts.hours }}小时）    |
 
 !!! 注意事项
-    加入候选收集人池将即刻生效。添加或增加委托也将即刻生效，但奖励会在 {{networks.moonriver.delegator_timings.rewards_payouts.rounds }}轮后开始发放。上表所列值可能会在未来发布新版本时有所调整。
+    加入候选收集人池将即刻生效。添加或增加委托也将即刻生效，但奖励会在 {{networks.moonriver.delegator_timings.rewards_payouts.rounds }}轮后开始发放。计算出的奖励会以线性方式释放，每个区块释放一次，直到所有奖励都释放完毕。每一个区块会随机选择一个收集人以及其委托人来发送奖励。假设有{{ networks.moonriver.staking.max_candidates }}个收集人, 那么全部收集人以及委托人会在新一轮开始后的第{{ networks.moonriver.staking.max_candidates }}块区块前收到奖励。上表所列值可能会在未来发布新版本时有所调整。
 
 ### 获取候选池的大小 {: #get-the-size-of-the-candidate-pool }
 

--- a/tokens/staking/stake.md
+++ b/tokens/staking/stake.md
@@ -30,6 +30,7 @@ Token持有者可以向候选人质押自己的Token，这一过程称为委托�
     | 单个候选人最大有效委托人数 |  |                                                    {{ networks.moonriver.staking.max_del_per_can }}                                                     |
     | 单个委托人可委托的最大候选人数  |  |                                                    {{ networks.moonriver.staking.max_del_per_del }}                                                     |
     |               轮次时长               |  |                        {{ networks.moonriver.staking.round_blocks }}区块（{{ networks.moonriver.staking.round_hours }}小时）                        |
+    |      委托生效期   |  |    委托在下一轮开始生效 （资金会马上绑定）                                        |
     |      离开委托人时长       |  |   {{ networks.moonriver.delegator_timings.leave_delegators.rounds }}轮（{{ networks.moonriver.delegator_timings.leave_delegators.hours }}小时）   |
     |     减少委托量时长     |  |      {{ networks.moonriver.delegator_timings.del_bond_less.rounds }}轮（{{ networks.moonriver.delegator_timings.del_bond_less.hours }}小时）      |
     |     撤销委托时长      |  | {{ networks.moonriver.delegator_timings.revoke_delegations.rounds }}轮（{{ networks.moonriver.delegator_timings.revoke_delegations.hours }}小时） |
@@ -41,6 +42,7 @@ Token持有者可以向候选人质押自己的Token，这一过程称为委托�
     | 单个候选人最大有效委托人数 |  |                                                    {{ networks.moonbase.staking.max_del_per_can }}                                                    |
     | 单个委托人可委托的最大候选人数  |  |                                                    {{ networks.moonbase.staking.max_del_per_del }}                                                    |
     |               轮次时长               |  |                        {{ networks.moonbase.staking.round_blocks }}区块（{{ networks.moonbase.staking.round_hours }}小时）                        |
+    |      委托生效期   |  |    委托在下一轮开始生效 （资金会马上绑定）                                        |
     |      离开委托人时长       |  |   {{ networks.moonbase.delegator_timings.leave_delegators.rounds }}轮（{{ networks.moonbase.delegator_timings.leave_delegators.hours }}小时）   |
     |     减少委托量时长     |  |      {{ networks.moonbase.delegator_timings.del_bond_less.rounds }}轮（{{ networks.moonbase.delegator_timings.del_bond_less.hours }}小时）      |
     |     撤销委托时长      |  | {{ networks.moonbase.delegator_timings.revoke_delegations.rounds }}轮（{{ networks.moonbase.delegator_timings.revoke_delegations.hours }}小时） |


### PR DESCRIPTION
### Description

Port staking changes to Chinese docs site.

### Checklist

- [x] If this requires translations for the `moonbeam-docs-cn` repo, I have created a ticket for the translations in Jira
- [x] If pages have been moved around, I have created an additional PR in `moonbeam-mkdocs` to update redirects
- [x] If images have been added, I have run the `compress-images.py` script to compress the images.
- [x] If images have been moved, I have created an additional PR in `moonbeam-docs-cn` to update images to their new paths
- [x] If variables (in variables.yml) need to be updated (such as a name change), I have updated the `moonbeam-docs-cn` repo to use the new variables

### Corresponding PRs

https://github.com/PureStake/moonbeam-docs/pull/215
https://github.com/PureStake/moonbeam-docs/pull/217
https://github.com/PureStake/moonbeam-docs/pull/219


### After Translation Requirements

- [ ] Will need to create PR in `moonbeam-docs` repo to remove images
- [ ] Will need to create PR in `moonbeam-docs` repo to remove variables
- [ ] Will need to create PR in `moonbeam-mkdocs` repo to add redirects for Chinese site
- [x] No additional PRs are required after the translations are done

#### Items to be Updated

None