### PR TITLE
Update Moonriver Democracy Param from Days to Hours

### DIFF
--- a/learn/platform/networks/moonriver.md
+++ b/learn/platform/networks/moonriver.md
@@ -41,7 +41,7 @@ _更新至2021年12月13日_
 |    变量    |                             数值                             |
 | :--------: | :----------------------------------------------------------: |
 |   投票期   | {{ networks.moonriver.democracy.vote_period.blocks}}区块（{{ networks.moonriver.democracy.vote_period.days}}天） |
-| 快速投票期 | {{ networks.moonriver.democracy.fast_vote_period.blocks}}区块（{{ networks.moonriver.democracy.fast_vote_period.days}}天） |
+| 快速投票期 | {{ networks.moonriver.democracy.fast_vote_period.blocks}}区块（{{ networks.moonriver.democracy.fast_vote_period.hours}}天） |
 |   颁布期   | {{ networks.moonriver.democracy.enact_period.blocks}}区块（{{ networks.moonriver.democracy.enact_period.days}}天） |
 |   冷却期   | {{ networks.moonriver.democracy.cool_period.blocks}}区块（{{ networks.moonriver.democracy.cool_period.days}}天） |
 | 最低保证金 |     {{ networks.moonriver.democracy.min_deposit }} MOVR      |


### PR DESCRIPTION
### Description/Original PRs

Updated a Moonriver Democracy Param in https://github.com/PureStake/moonbeam-docs/pull/234, need to update it here as well. 

### Checklist

- [ ] If this requires removing old images from the `moonbeam-docs` repo, I have created a corresponding PR
- [ ] If this requires adding/updating/deleting redirects, I have created a corresponding PR in the `moonbeam-mkdocs` repo
- [ ] If this requires removing old variables from the `moonbeam-docs` repo, I have created a corresponding PR

### Corresponding PRs

Please link to any additional corresponding PRs here.
