### PR TITLE
update chainlink price feeds for moonriver

### DIFF
--- a/builders/integrations/oracles/chainlink.md
+++ b/builders/integrations/oracles/chainlink.md
@@ -63,31 +63,55 @@ interface AggregatorV3Interface {
 目前，我们部署了以下报价对的Data Feed合约：
 
 === "Moonriver"
-    | 基础报价对  |  |                        Data Feed合约                        |
-    |:-----------:|--|:-----------------------------------------------------------:|
-    | BTC to USD  |  | {{ networks.moonriver.chainlink.feed.aggregator.btc_usd }}  |
-    | ETH to USD  |  | {{ networks.moonriver.chainlink.feed.aggregator.eth_usd }}  |
-    | KSM to USD  |  | {{ networks.moonriver.chainlink.feed.aggregator.ksm_usd }}  |
-    | LINK to USD |  | {{ networks.moonriver.chainlink.feed.aggregator.link_usd }} |
-    | BNB to USD  |  | {{ networks.moonriver.chainlink.feed.aggregator.bnb_usd }}  |
-    | FRAX to USD |  | {{ networks.moonriver.chainlink.feed.aggregator.frax_usd }} |
-    | MIM to USD  |  | {{ networks.moonriver.chainlink.feed.aggregator.mim_usd }}  |
-    | MOVR to USD |  | {{ networks.moonriver.chainlink.feed.aggregator.movr_usd }} |
-    | USDT to USD |  | {{ networks.moonriver.chainlink.feed.aggregator.usdt_usd }} |
+    |  基础报价对  |                        Data Feed合约                         |
+    |:------------:|:------------------------------------------------------------:|
+    | 1INCH to USD | {{ networks.moonriver.chainlink.feed.aggregator.inch_usd }}  |
+    | AAVE to USD  | {{ networks.moonriver.chainlink.feed.aggregator.aave_usd }}  |
+    | ANKR to USD  | {{ networks.moonriver.chainlink.feed.aggregator.ankr_usd }}  |
+    | AVAX to USD  | {{ networks.moonriver.chainlink.feed.aggregator.avax_usd }}  |
+    |  AXS to USD  |  {{ networks.moonriver.chainlink.feed.aggregator.axs_usd }}  |
+    |  BNB to USD  |  {{ networks.moonriver.chainlink.feed.aggregator.bnb_usd }}  |
+    |  BTC to USD  |  {{ networks.moonriver.chainlink.feed.aggregator.btc_usd }}  |
+    | CAKE to USD  | {{ networks.moonriver.chainlink.feed.aggregator.cake_usd }}  |
+    | COMP to USD  | {{ networks.moonriver.chainlink.feed.aggregator.comp_usd }}  |
+    |  CRV to USD  |  {{ networks.moonriver.chainlink.feed.aggregator.crv_usd }}  |
+    |  DAI to USD  |  {{ networks.moonriver.chainlink.feed.aggregator.dai_usd }}  |
+    |  DOT to USD  |  {{ networks.moonriver.chainlink.feed.aggregator.dot_usd }}  |
+    |  ETH to USD  |  {{ networks.moonriver.chainlink.feed.aggregator.eth_usd }}  |
+    |  EUR to USD  |  {{ networks.moonriver.chainlink.feed.aggregator.eur_usd }}  |
+    | FRAX to USD  | {{ networks.moonriver.chainlink.feed.aggregator.frax_usd }}  |
+    |  FTM to USD  |  {{ networks.moonriver.chainlink.feed.aggregator.ftm_usd }}  |
+    |  FXS to USD  |  {{ networks.moonriver.chainlink.feed.aggregator.fxs_usd }}  |
+    |  KSM to USD  |  {{ networks.moonriver.chainlink.feed.aggregator.ksm_usd }}  |
+    | LINK to USD  | {{ networks.moonriver.chainlink.feed.aggregator.link_usd }}  |
+    | LUNA to USD  | {{ networks.moonriver.chainlink.feed.aggregator.luna_usd }}  |
+    | MANA to USD  | {{ networks.moonriver.chainlink.feed.aggregator.mana_usd }}  |
+    |  MIM to USD  |  {{ networks.moonriver.chainlink.feed.aggregator.mim_usd }}  |
+    |  MKR to USD  |  {{ networks.moonriver.chainlink.feed.aggregator.mkr_usd }}  |
+    | MOVR to USD  | {{ networks.moonriver.chainlink.feed.aggregator.movr_usd }}  |
+    | SAND to USD  | {{ networks.moonriver.chainlink.feed.aggregator.sand_usd }}  |
+    |  SNX to USD  |  {{ networks.moonriver.chainlink.feed.aggregator.snx_usd }}  |
+    | SUSHI to USD | {{ networks.moonriver.chainlink.feed.aggregator.sushi_usd }} |
+    | THETA to USD | {{ networks.moonriver.chainlink.feed.aggregator.theta_usd }} |
+    |  UNI to USD  |  {{ networks.moonriver.chainlink.feed.aggregator.uni_usd }}  |
+    | USDC to USD  | {{ networks.moonriver.chainlink.feed.aggregator.usdc_usd }}  |
+    | USDT to USD  | {{ networks.moonriver.chainlink.feed.aggregator.usdt_usd }}  |
+    |  XRP to USD  |  {{ networks.moonriver.chainlink.feed.aggregator.xrp_usd }}  |
+    |  YFI to USD  |  {{ networks.moonriver.chainlink.feed.aggregator.yfi_usd }}  |
     
 === "Moonbase Alpha"
-    |  基础报价对  |  |                        Data Feed合约                        |
-    |:------------:|--|:-----------------------------------------------------------:|
-    |  BTC to USD  |  |  {{ networks.moonbase.chainlink.feed.aggregator.btc_usd }}  |
-    |  ETH to USD  |  |  {{ networks.moonbase.chainlink.feed.aggregator.eth_usd }}  |
-    |  DOT to USD  |  |  {{ networks.moonbase.chainlink.feed.aggregator.dot_usd }}  |
-    |  KSM to USD  |  |  {{ networks.moonbase.chainlink.feed.aggregator.ksm_usd }}  |
-    | AAVE to USD  |  | {{ networks.moonbase.chainlink.feed.aggregator.aave_usd }}  |
-    | ALGO to USD  |  | {{ networks.moonbase.chainlink.feed.aggregator.algo_usd }}  |
-    | BAND to USD  |  | {{ networks.moonbase.chainlink.feed.aggregator.band_usd }}  |
-    | LINK to USD  |  | {{ networks.moonbase.chainlink.feed.aggregator.link_usd }}  |
-    | SUSHI to USD |  | {{ networks.moonbase.chainlink.feed.aggregator.sushi_usd }} |
-    |  UNI to USD  |  |  {{ networks.moonbase.chainlink.feed.aggregator.uni_usd }}  |
+    |  基础报价对  |                        Data Feed合约                        |
+    |:------------:|:-----------------------------------------------------------:|
+    |  BTC to USD  |  {{ networks.moonbase.chainlink.feed.aggregator.btc_usd }}  |
+    |  ETH to USD  |  {{ networks.moonbase.chainlink.feed.aggregator.eth_usd }}  |
+    |  DOT to USD  |  {{ networks.moonbase.chainlink.feed.aggregator.dot_usd }}  |
+    |  KSM to USD  |  {{ networks.moonbase.chainlink.feed.aggregator.ksm_usd }}  |
+    | AAVE to USD  | {{ networks.moonbase.chainlink.feed.aggregator.aave_usd }}  |
+    | ALGO to USD  | {{ networks.moonbase.chainlink.feed.aggregator.algo_usd }}  |
+    | BAND to USD  | {{ networks.moonbase.chainlink.feed.aggregator.band_usd }}  |
+    | LINK to USD  | {{ networks.moonbase.chainlink.feed.aggregator.link_usd }}  |
+    | SUSHI to USD | {{ networks.moonbase.chainlink.feed.aggregator.sushi_usd }} |
+    |  UNI to USD  |  {{ networks.moonbase.chainlink.feed.aggregator.uni_usd }}  |
 
 举例而言，您可以通过[Remix](https://remix.ethereum.org/)使用Aggregator接口获取`BTC to USD`喂价。如果您需要加载合约至Remix，请参考[使用Remix](/builders/interact/remix/)文档。
 


### PR DESCRIPTION
### Description/Original PRs

Adds new chainlink price feeds for Moonriver. Goes with https://github.com/PureStake/moonbeam-docs/pull/271

