### PR TITLE
update the runtime cache size value

### DIFF
--- a/node-operators/networks/run-a-node/flags.md
+++ b/node-operators/networks/run-a-node/flags.md
@@ -38,7 +38,7 @@ description: 有助于在Moonbeam上运行一个完整平行链节点的标志�
 - **`--telemetry-url`** —— 指定telemetry服务器所连接的URL。此标志能够用于为多个telemetry端点多次使用。此标志使用两个参数，分别为URL和日志详细级别（Verbosity Level）。日志详细级别范围为0-9，0代表最低级别。预期使用此标志的格式为'<URL VERBOSITY>'，如`--telemetry-url 'wss://foo/bar 0'`
 - **`--in-peers`** —— 指定可接受向内连接的最大数量，默认为`25`
 - **`--out-peers`** —— 指定可接受向外连接的最大数量以维持稳定，默认为`25`
-- **`--runtime-cache-size 32`** - 将保留在内存缓存中的不同运行时版本的数量配置为`32`
+- **`--runtime-cache-size 64`** - 将保留在内存缓存中的不同运行时版本的数量配置为`64`
 
 ## 如何访问所有可用标志 {: #how-to-access-all-of-the-available-flags }
 

--- a/node-operators/networks/tracing-node.md
+++ b/node-operators/networks/tracing-node.md
@@ -75,7 +75,7 @@ Geth的`debug`和`txpool` API以及OpenEthereum的`trace`模块提供一个非�
   - **`--ethapi=trace`** — 选择性标识，启用`trace_filter` 
   - **`--ethapi=txpool`** — 选择性标识，启用`txpool_content`、`txpool_inspect`和`txpool_status`
   - **`--wasm-runtime-overrides=/moonbeam/<network>-substitutes-tracing`** — **必备** 用于追踪指定存储本地WASM runtime路径的标识。接受网络作为参数`moonbeam`、`moonriver`或`moonbase`（用于Moonbeam开发节点和Moonbase Alpha）
-  - **`--runtime-cache-size 32`** - **必备** 将内存缓存中保留的不同运行时版本的数量配置为32的标志
+  - **`--runtime-cache-size 64`** - **必备** 将内存缓存中保留的不同运行时版本的数量配置为64的标志
 
 运行追踪节点的完整命令如以下所示：
 
@@ -95,7 +95,7 @@ Geth的`debug`和`txpool` API以及OpenEthereum的`trace`模块提供一个非�
     --db-cache <50% RAM in MB> \
     --ethapi=debug,trace,txpool \
     --wasm-runtime-overrides=/moonbeam/moonbeam-substitutes-tracing \
-    --runtime-cache-size 32 \
+    --runtime-cache-size 64 \
     -- \
     --execution wasm \
     --pruning 1000 \
@@ -115,7 +115,7 @@ Geth的`debug`和`txpool` API以及OpenEthereum的`trace`模块提供一个非�
     --db-cache <50% RAM in MB> \
     --ethapi=debug,trace,txpool \
     --wasm-runtime-overrides=/moonbeam/moonriver-substitutes-tracing \
-    --runtime-cache-size 32 \
+    --runtime-cache-size 64 \
     -- \
     --execution wasm \
     --pruning 1000 \
@@ -135,7 +135,7 @@ Geth的`debug`和`txpool` API以及OpenEthereum的`trace`模块提供一个非�
     --db-cache <50% RAM in MB> \
     --ethapi=debug,trace,txpool \
     --wasm-runtime-overrides=/moonbeam/moonbase-substitutes-tracing \
-    --runtime-cache-size 32 \
+    --runtime-cache-size 64 \
     -- \
     --execution wasm \
     --pruning 1000 \
@@ -150,7 +150,7 @@ Geth的`debug`和`txpool` API以及OpenEthereum的`trace`模块提供一个非�
     --name="Moonbeam-Tutorial" \
     --ethapi=debug,trace,txpool \
     --wasm-runtime-overrides=/moonbeam/moonbase-substitutes-tracing \
-    --runtime-cache-size 32 \
+    --runtime-cache-size 64 \
     --dev
     ```
 


### PR DESCRIPTION
### Description/Original PRs

Update the --runtime-cache-size flag value to be 64 instead of 32

Goes with EN PR# https://github.com/PureStake/moonbeam-docs/pull/328
