### PR TITLE
Mkdocs updates

### DIFF
--- a/builders/build/eth-api/dev-env/index.md
+++ b/builders/build/eth-api/dev-env/index.md
@@ -2,6 +2,9 @@
 title: 以太坊开发环境
 description: 了解如何使用 Remix、OpenZeppelin、Hardhat、Truffle、Waffle & Mars 等以太坊工具在 Moonbeam 上开发 Solidity 智能合约。
 template: main.html
+hide:
+  - toc
 ---
 
+<h1 class='subsection-title'></h1>
 <div class='subsection-wrapper'></div>

--- a/builders/build/eth-api/dev-env/openzeppelin/index.md
+++ b/builders/build/eth-api/dev-env/openzeppelin/index.md
@@ -2,6 +2,9 @@
 title: 与Openzeppelin交互
 description: 使用 OpenZeppelin合约和库、Contract Wizard或Defender在Moonbeam上创建和管理您的Solidity智能合约。
 template: main.html
+hide:
+  - toc
 ---
 
+<h1 class='subsection-title'></h1>
 <div class='subsection-wrapper'></div>

--- a/builders/build/eth-api/index.md
+++ b/builders/build/eth-api/index.md
@@ -2,6 +2,9 @@
 title: 以太坊API
 description: 了解在 Moonbeam 上进行开发时如何使用 Ethereum API。本节包括有关以太坊库、开发环境等的指南。
 template: main.html
+hide:
+  - toc
 ---
 
+<h1 class='subsection-title'></h1>
 <div class='subsection-wrapper'></div>

--- a/builders/build/eth-api/libraries/index.md
+++ b/builders/build/eth-api/libraries/index.md
@@ -2,6 +2,9 @@
 title: 以太坊库
 description: 了解如何使用JavaScript或Python以太坊库（例如Ethers.js、Web3.js或Web3.py）在Moonbeam上发送交易或部署合约。
 template: main.html
+hide:
+  - toc
 ---
 
+<h1 class='subsection-title'></h1>
 <div class='subsection-wrapper'></div>

--- a/builders/build/eth-api/verify-contracts/index.md
+++ b/builders/build/eth-api/verify-contracts/index.md
@@ -2,6 +2,9 @@
 title: 验证智能合约
 description: 了解如何通过区块浏览器验证部署到Moonbeam的Solidity智能合约，或通过Etherscan插件自动验证。
 template: main.html
+hide:
+  - toc
 ---
 
+<h1 class='subsection-title'></h1>
 <div class='subsection-wrapper'></div>

--- a/builders/build/index.md
+++ b/builders/build/index.md
@@ -2,6 +2,9 @@
 title: 在Moonbeam上开发的指南
 description: 学习如何使用以太坊和Substrate API以部署、验证和与合约交互以及在Moonbeam上开发DApp的指南。
 template: main.html
+hide:
+  - toc
 ---
 
+<h1 class='subsection-title'></h1>
 <div class='subsection-wrapper'></div>

--- a/builders/build/substrate-api/index.md
+++ b/builders/build/substrate-api/index.md
@@ -2,6 +2,9 @@
 title: Substrate API
 description: 了解在 Moonbeam上如何与Substrate API交互，包括如何使用Polkadot.js API查询Moonbeam数据等。
 template: main.html
+hide:
+  - toc
 ---
 
+<h1 class='subsection-title'></h1>
 <div class='subsection-wrapper'></div>

--- a/builders/get-started/eth-compare/index.md
+++ b/builders/get-started/eth-compare/index.md
@@ -2,6 +2,9 @@
 title: Moonbeam与以太坊比较
 description: 深入了解 Moonbeam（以太坊兼容区块链）与以太坊本身之间的一些主要区别。
 template: main.html
+hide:
+  - toc
 ---
 
+<h1 class='subsection-title'></h1>
 <div class='subsection-wrapper'></div>

--- a/builders/get-started/index.md
+++ b/builders/get-started/index.md
@@ -2,6 +2,9 @@
 title: 开始使用Moonbeam
 description: 在Moonbeam上开始开发、部署和与智能合约交互所需了解的一切。
 template: main.html
+hide:
+  - toc
 ---
 
+<h1 class='subsection-title'></h1>
 <div class='subsection-wrapper'></div>

--- a/builders/get-started/networks/index.md
+++ b/builders/get-started/networks/index.md
@@ -2,6 +2,9 @@
 title: 开始使用基于Moonbeam的网络
 description: 了解如何开始在Moonbeam开发节点、Moonbase Alpha测试网、Moonriver、Moonbeam或Boba Layer 2上进行开发。
 template: main.html
+hide:
+  - toc
 ---
 
+<h1 class='subsection-title'></h1>
 <div class='subsection-wrapper'></div>

--- a/builders/get-started/networks/layer2/index.md
+++ b/builders/get-started/networks/layer2/index.md
@@ -2,6 +2,9 @@
 title: Boba Layer 2
 description: 了解如何连接和实用Bobabeam Layer 2来进行开发的相关指南。
 template: main.html
+hide:
+  - toc
 ---
 
+<h1 class='subsection-title'></h1>
 <div class='subsection-wrapper'></div>

--- a/builders/index.md
+++ b/builders/index.md
@@ -2,8 +2,11 @@
 title: Moonbeam开发者文档汇集
 description: Moonbeam入门和开发指南。了解如何使用Ethereum和Substrate API、XCM互操作性和其它可用的集成。
 template: main.html
+hide:
+  - toc
 ---
 
+<h1 class='subsection-title'></h1>
 <div class='subsection-wrapper'></div>
 <div class='disclaimer'>
 --8<-- 'text/disclaimers/general.md'

--- a/builders/integrations/analytics/index.md
+++ b/builders/integrations/analytics/index.md
@@ -2,6 +2,9 @@
 title: 分析链上数据 
 description: 通过构建图表和仪表板来分析链上智能合约数据，以可视化数据跟踪Moonbeam和Moonriver的指标。
 template: main.html
+hide:
+  - toc
 ---
 
+<h1 class='subsection-title'></h1>
 <div class='subsection-wrapper'></div>

--- a/builders/integrations/index.md
+++ b/builders/integrations/index.md
@@ -2,6 +2,9 @@
 title: Moonbeam上的集成
 description: 了解Moonbeam上可用于DApp开发的集成，包括桥接器、索引器、预言机和钱包。
 template: main.html
+hide:
+  - toc
 ---
 
+<h1 class='subsection-title'></h1>
 <div class='subsection-wrapper'></div>

--- a/builders/integrations/indexers/index.md
+++ b/builders/integrations/indexers/index.md
@@ -2,6 +2,9 @@
 title: 索引器和API
 description: 了解如何从Moonbeam支持的索引器之一（例如 Covalent、The Graph 或 SubQuery）构建您自己的API或API端点。
 template: main.html
+hide:
+  - toc
 ---
 
+<h1 class='subsection-title'></h1>
 <div class='subsection-wrapper'></div>

--- a/builders/integrations/oracles/index.md
+++ b/builders/integrations/oracles/index.md
@@ -2,6 +2,9 @@
 title: 在DApp中使用语言机
 description: 了解如何将诸如ChainLink、Band或Razor Network之类的预言机添加到您的DApp中，以使用Moonbeam上运行的智能合约请求链下数据。
 template: main.html
+hide:
+  - toc
 ---
 
+<h1 class='subsection-title'></h1>
 <div class='subsection-wrapper'></div>

--- a/builders/integrations/relayers/index.md
+++ b/builders/integrations/relayers/index.md
@@ -2,6 +2,9 @@
 title: 中继器
 description: 了解如何使用交易中继器执行免Gas费的交易以及智能合约交互的重复执行或有其它自动化。
 template: main.html
+hide:
+  - toc
 ---
 
+<h1 class='subsection-title'></h1>
 <div class='subsection-wrapper'></div>

--- a/builders/integrations/wallets/index.md
+++ b/builders/integrations/wallets/index.md
@@ -2,6 +2,9 @@
 title: 将钱包集成添加到DApp
 description: 了解如何将MetaMask和WalletConnect等钱包集成添加到Moonbeam上的DApp，以便用户可以自动连接到他们的钱包。
 template: main.html
+hide:
+  - toc
 ---
 
+<h1 class='subsection-title'></h1>
 <div class='subsection-wrapper'></div>

--- a/builders/interoperability/index.md
+++ b/builders/interoperability/index.md
@@ -2,6 +2,9 @@
 title: 互操作性
 description: 通过深入了解跨链共识消息(XCM)的工作原理以及探索已有的跨链协议来学习Moonbeam上的互操作性。
 template: main.html
+hide:
+  - toc
 ---
 
+<h1 class='subsection-title'></h1>
 <div class='subsection-wrapper'></div>

--- a/builders/interoperability/protocols/index.md
+++ b/builders/interoperability/protocols/index.md
@@ -2,6 +2,9 @@
 title: 跨链协议
 description: 了解跨链协议，用以在Moonbeam和任意已建立连接的链之间安全地转移资产
 template: main.html
+hide:
+  - toc
 ---
 
+<h1 class='subsection-title'></h1>
 <div class='subsection-wrapper'></div>

--- a/builders/interoperability/xcm/index.md
+++ b/builders/interoperability/xcm/index.md
@@ -2,6 +2,9 @@
 title: 跨链通信
 description: 概述跨链共识消息(XCM)的工作原理，以及开发者如何利用Polkadot/Kusama XCM将资产转移到 Moonbeam，或从Moonbeam转移出资产。
 template: main.html
+hide:
+  - toc
 ---
 
+<h1 class='subsection-title'></h1>
 <div class='subsection-wrapper'></div>

--- a/builders/interoperability/xcm/xc20/index.md
+++ b/builders/interoperability/xcm/xc20/index.md
@@ -2,6 +2,9 @@
 title: 跨链资产和XC-20
 description: 了解称为XC-20的跨链资产，以及如何通过Moonbeam上的以太坊API与其交互。
 template: main.html
+hide:
+  - toc
 ---
 
+<h1 class='subsection-title'></h1>
 <div class='subsection-wrapper'></div>

--- a/builders/interoperability/xcm/xcm-sdk/index.md
+++ b/builders/interoperability/xcm/xcm-sdk/index.md
@@ -2,6 +2,9 @@
 title: XCM SDK 指南
 description: Moonbeam XCM的SDK中可用的方法和接口，以及如何使用XCM的SDK轻松存取跨链资产的指南
 template: main.html
+hide:
+  - toc
 ---
 
+<h1 class='subsection-title'></h1>
 <div class='subsection-wrapper'></div>

--- a/builders/pallets-precompiles/index.md
+++ b/builders/pallets-precompiles/index.md
@@ -2,6 +2,9 @@
 title: Moonbeam开发指南
 description: 学习如何与以太坊和Substrate API交互以部署、验证和交互合约，以及在Moonbeam上开发DApp的指南。
 template: main.html
+hide:
+  - toc
 ---
 
+<h1 class='subsection-title'></h1>
 <div class='subsection-wrapper'></div>

--- a/builders/pallets-precompiles/pallets/index.md
+++ b/builders/pallets-precompiles/pallets/index.md
@@ -2,6 +2,9 @@
 title: Pallets
 description: 了解Moonbeam上可用的pallet，以及如何通过相关的extrinsic和它们的Solidity接口（如果适用）与它们交互。
 template: main.html
+hide:
+  - toc
 ---
 
+<h1 class='subsection-title'></h1>
 <div class='subsection-wrapper'></div>

--- a/builders/pallets-precompiles/precompiles/index.md
+++ b/builders/pallets-precompiles/precompiles/index.md
@@ -2,6 +2,9 @@
 title: Solidity预编译合约
 description: 与Moonbeam上的预编译合约交互的指南列表，使您能够使用Ethereum API与Substrate功能进行交互。
 template: main.html
+hide:
+  - toc
 ---
 
+<h1 class='subsection-title'></h1>
 <div class='subsection-wrapper'></div>

--- a/index.md
+++ b/index.md
@@ -4,4 +4,5 @@ description: 深入了解如何使用Moonbeam（基于波卡的EVM兼容平行�
 template: home.html
 ---
 
-<div class="subsection-wrapper"></div>
+<h1 class='subsection-title'></h1>
+<div class='subsection-wrapper'></div>

--- a/learn/dapps-list/index.md
+++ b/learn/dapps-list/index.md
@@ -2,6 +2,8 @@
 title: DApp排名列表
 description: 了解Moonbeam和Moonriver上的一些DApp列表，以及如何将您自己的DApp上架到这些服务。
 template: main.html
+hide:
+  - toc
 ---
 
 <div class="subsection-wrapper">

--- a/learn/features/index.md
+++ b/learn/features/index.md
@@ -2,6 +2,9 @@
 title: 功能
 description: 了解Moonbeam的一些主要功能，包括以太坊兼容性、互操作性、共识框架、质押、治理等。
 template: main.html
+hide:
+  - toc
 ---
 
+<h1 class='subsection-title'></h1>
 <div class='subsection-wrapper'></div>

--- a/learn/index.md
+++ b/learn/index.md
@@ -2,8 +2,11 @@
 title: 了解Moonbeam
 description: 了解有关Moonbeam的所有信息，包括有关以太坊兼容智能合约平台及其引人注目的功能的基础知识。
 template: main.html
+hide:
+  - toc
 ---
 
+<h1 class='subsection-title'></h1>
 <div class='subsection-wrapper'></div>
 <div class='disclaimer'>
 --8<-- 'text/disclaimers/general.md'

--- a/learn/platform/index.md
+++ b/learn/platform/index.md
@@ -2,6 +2,9 @@
 title: 智能合约平台
 description: 了解Moonbeam智能合约平台，包括Moonbeam网络、愿景、路线图、技术、代币等。
 template: main.html
+hide:
+  - toc
 ---
 
+<h1 class='subsection-title'></h1>
 <div class='subsection-wrapper'></div>

--- a/learn/platform/networks/index.md
+++ b/learn/platform/networks/index.md
@@ -2,6 +2,9 @@
 title: 网络
 description: 了解每个Moonbeam网络的基础信息，包括Moonbeam、Moonriver和 Moonbase Alpha测试网。
 template: main.html
+hide:
+  - toc
 ---
 
+<h1 class='subsection-title'></h1>
 <div class='subsection-wrapper'></div>

--- a/node-operators/index.md
+++ b/node-operators/index.md
@@ -2,8 +2,11 @@
 title: 节点运营和收集人节点
 description: 了解如何在Moonbeam上运营节点，包括运行Moonbeam全节点、收集器节点、索引器节点和预言机节点。
 template: main.html
+hide:
+  - toc
 ---
 
+<h1 class='subsection-title'></h1>
 <div class='subsection-wrapper'></div>
 <div class='disclaimer'>
 --8<-- 'text/disclaimers/general.md'

--- a/node-operators/indexer-nodes/index.md
+++ b/node-operators/indexer-nodes/index.md
@@ -2,6 +2,9 @@
 title: 运行索引器节点
 description: 了解如何在Moonbeam上运行索引器节点，例如Graph节点，以提供链上数据的索引和查询服务。
 template: main.html
+hide:
+  - toc
 ---
 
+<h1 class='subsection-title'></h1>
 <div class='subsection-wrapper'></div>

--- a/node-operators/networks/collators/index.md
+++ b/node-operators/networks/collators/index.md
@@ -2,6 +2,9 @@
 title: 收集人（区块生产者）
 description: 了解如何成为收集人并在Moonbeam上生产区块，包括要求、设置帐户、绑定、加入收集者池、常见问题解答等。
 template: main.html
+hide:
+  - toc
 ---
 
+<h1 class='subsection-title'></h1>
 <div class='subsection-wrapper'></div>

--- a/node-operators/networks/index.md
+++ b/node-operators/networks/index.md
@@ -2,6 +2,9 @@
 title: 运行全节点、Tracing节点或收集人节点
 description: 了解如何在Moonbeam上运行全节点、Tracing节点或收集人节点，以及成为收集人节点的要求。
 template: main.html
+hide:
+  - toc
 ---
 
+<h1 class='subsection-title'></h1>
 <div class='subsection-wrapper'></div>

--- a/node-operators/networks/run-a-node/index.md
+++ b/node-operators/networks/run-a-node/index.md
@@ -2,6 +2,9 @@
 title: 运行平行链全节点
 description: 了解如何使用Docker或Systemd在任何基于Moonbeam的网络上运行全节点，这样您就可以拥有自己的RPC端点或收集人节点。
 template: main.html
+hide:
+  - toc
 ---
 
+<h1 class='subsection-title'></h1>
 <div class='subsection-wrapper'></div>

--- a/node-operators/oracle-nodes/index.md
+++ b/node-operators/oracle-nodes/index.md
@@ -2,6 +2,9 @@
 title: 运行语言机节点
 description: 在Moonbeam上运行预言机节点，例如ChainLink节点，并为在Moonbeam上运行的智能合约提供链下数据。
 template: main.html
+hide:
+  - toc
 ---
 
+<h1 class='subsection-title'></h1>
 <div class='subsection-wrapper'></div>

--- a/tokens/connect/index.md
+++ b/tokens/connect/index.md
@@ -2,6 +2,9 @@
 title: 将您的钱包连接到Moonbeam
 description: 了解一些可用于Moonbeam的钱包，以及如何连接您的钱包，并使用它与Moonbeam网络进行交互。
 template: main.html
+hide:
+  - toc
 ---
 
+<h1 class='subsection-title'></h1>
 <div class='subsection-wrapper'></div>

--- a/tokens/connect/ledger/index.md
+++ b/tokens/connect/ledger/index.md
@@ -2,6 +2,9 @@
 title: 连接和使用Ledger
 description: 了解如何使用Ledger硬件钱包在Moonbeam网络上签署交易，通过Ledger原生Moonbeam和Moonriver应用程序以及Ethereum应用程序。
 template: main.html
+hide:
+  - toc
 ---
 
+<h1 class='subsection-title'></h1>
 <div class='subsection-wrapper'></div>

--- a/tokens/governance/index.md
+++ b/tokens/governance/index.md
@@ -2,6 +2,9 @@
 title: 参与治理
 description: 了解如何参与Moonbeam的链上治理，包括如何提出提案以及如何对提案进行投票。
 template: main.html
+hide:
+  - toc
 ---
 
+<h1 class='subsection-title'></h1>
 <div class='subsection-wrapper'></div>

--- a/tokens/index.md
+++ b/tokens/index.md
@@ -2,8 +2,11 @@
 title: 如何使用您的GLMR和MOVR代币
 description: 一系列使用和管理您的GLMR和MOVR代币的指南，包括支持的钱包、参与治理和质押等等。
 template: main.html
+hide:
+  - toc
 ---
 
+<h1 class='subsection-title'></h1>
 <div class='subsection-wrapper'></div>
 <div class='disclaimer'>
 --8<-- 'text/disclaimers/general.md'

--- a/tokens/manage/index.md
+++ b/tokens/manage/index.md
@@ -2,6 +2,9 @@
 title: 管理和保护您的帐户
 description: 了解如何通过创建链上身份以及设置多签保险箱和代理帐户等方式来管理和保护您在Moonbeam上的帐户。
 template: main.html
+hide:
+  - toc
 ---
 
+<h1 class='subsection-title'></h1>
 <div class='subsection-wrapper'></div>

--- a/tokens/staking/index.md
+++ b/tokens/staking/index.md
@@ -2,6 +2,9 @@
 title: 如何质押GLMR和MOVR代币
 description: 了解如何委托收集人候选人并质押您的GLMR和MOVR代币，以在Moonbeam和Moonriver上获得质押奖励。
 template: main.html
+hide:
+  - toc
 ---
 
+<h1 class='subsection-title'></h1>
 <div class='subsection-wrapper'></div>


### PR DESCRIPTION
### Description/Original PRs

This PR makes the necessary changes for the site to render as expected with the latest updates to mkdocs.

- `hide: - toc` is needed so that the right side table of contents menu doesn't appear on index pages
- `<h1 class='subsection-title'></h1>` is needed so that the title of the index page renders (i.e. how builders shows up over the get started, build, etc. cards: https://docs.moonbeam.network/builders/)

### Corresponding PRs

https://github.com/PureStake/moonbeam-mkdocs/pull/102
https://github.com/PureStake/moonbeam-docs/pull/533