### PR TITLE
bump macos snippets to v0.29.0

### DIFF
--- a/.snippets/text/full-node/macos-node.md
+++ b/.snippets/text/full-node/macos-node.md
@@ -47,7 +47,7 @@ purestake/moonbeam:v0.28.1 \
 ```
 docker run -p 9933:9933 -p 9944:9944 -v "/var/lib/moonriver-data:/data" \
 -u $(id -u ${USER}):$(id -g ${USER}) \
-purestake/moonbeam:v0.28.1 \
+purestake/moonbeam:v0.29.0 \
 --base-path=/data \
 --chain moonriver \
 --name="YOUR-NODE-NAME" \
@@ -65,7 +65,7 @@ purestake/moonbeam:v0.28.1 \
 ```
 docker run -p 9933:9933 -p 9944:9944 -v "/var/lib/moonriver-data:/data" \
 -u $(id -u ${USER}):$(id -g ${USER}) \
-purestake/moonbeam:v0.28.1 \
+purestake/moonbeam:v0.29.0 \
 --base-path=/data \
 --chain moonriver \
 --name="YOUR-NODE-NAME" \
@@ -83,7 +83,7 @@ purestake/moonbeam:v0.28.1 \
 ```
 docker run -p 9933:9933 -p 9944:9944 -v "/var/lib/alphanet-data:/data" \
 -u $(id -u ${USER}):$(id -g ${USER}) \
-purestake/moonbeam:v0.28.1 \
+purestake/moonbeam:v0.29.0 \
 --base-path=/data \
 --chain alphanet \
 --name="YOUR-NODE-NAME" \
@@ -101,7 +101,7 @@ purestake/moonbeam:v0.28.1 \
 ```
 docker run -p 9933:9933 -p 9944:9944 -v "/var/lib/alphanet-data:/data" \
 -u $(id -u ${USER}):$(id -g ${USER}) \
-purestake/moonbeam:v0.28.1 \
+purestake/moonbeam:v0.29.0 \
 --base-path=/data \
 --chain alphanet \
 --name="YOUR-NODE-NAME" \


### PR DESCRIPTION
### Description/Original PRs

This PR bumps the macos snippets to v0.29.0 for moonriver and moonbase
