### PR TITLE
bump to v0.29.0 on moonbeam

### DIFF
--- a/.snippets/text/full-node/macos-node.md
+++ b/.snippets/text/full-node/macos-node.md
@@ -11,7 +11,7 @@ title: 适用于MacOS的全节点Docker命令
 ```
 docker run -p 9933:9933 -p 9944:9944 -v "/var/lib/moonbeam-data:/data" \
 -u $(id -u ${USER}):$(id -g ${USER}) \
-purestake/moonbeam:v0.28.1 \
+purestake/moonbeam:v0.29.0 \
 --base-path=/data \
 --chain moonbeam \
 --name="YOUR-NODE-NAME" \
@@ -29,7 +29,7 @@ purestake/moonbeam:v0.28.1 \
 ```
 docker run -p 9933:9933 -p 9944:9944 -v "/var/lib/moonbeam-data:/data" \
 -u $(id -u ${USER}):$(id -g ${USER}) \
-purestake/moonbeam:v0.28.1 \
+purestake/moonbeam:v0.29.0 \
 --base-path=/data \
 --chain moonbeam \
 --name="YOUR-NODE-NAME" \


### PR DESCRIPTION
### Description/Original PRs

Bumps the client version to v0.29.0 for Moonbeam
Goes with EN PR: https://github.com/PureStake/moonbeam-docs/pull/551