### PR TITLE
update polkadot.js app links

### DIFF
--- a/.snippets/text/explorers/explorers.md
+++ b/.snippets/text/explorers/explorers.md
@@ -5,7 +5,7 @@
     | Blockscout  |    EVM    |                               [https://blockscout.moonbeam.network/](https://blockscout.moonbeam.network/){target=_blank}                                |
     | Expedition  |    EVM    |            [https://moonbeam-explorer.netlify.app/?network=Moonbeam](https://moonbeam-explorer.netlify.app/?network=Moonbeam){target=_blank}             |
     |   Subscan   | Substrate |                                       [https://moonbeam.subscan.io/](https://moonbeam.subscan.io/){target=_blank}                                        |
-    | Polkadot.js | Substrate | [https://polkadot.js.org/apps/#/explorer](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fmoonbeam.api.onfinality.io%2Fpublic-ws#/explorer){target=_blank} |
+    | Polkadot.js | Substrate | [https://polkadot.js.org/apps/#/explorer](https://polkadot.js.org/apps/?rpc=wss://wss.api.moonbeam.network#/explorer){target=_blank} |
 
 
 === "Moonriver"
@@ -15,7 +15,7 @@
     | Blockscout  |    EVM    |                      [https://blockscout.moonriver.moonbeam.network/](https://blockscout.moonriver.moonbeam.network/){target=_blank}                      |
     | Expedition  |    EVM    |            [https://moonbeam-explorer.netlify.app/?network=Moonriver](https://moonbeam-explorer.netlify.app/?network=Moonriver){target=_blank}            |
     |   Subscan   | Substrate |                                       [https://moonriver.subscan.io/](https://moonriver.subscan.io/){target=_blank}                                       |
-    | Polkadot.js | Substrate | [https://polkadot.js.org/apps/#/explorer](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fmoonriver.api.onfinality.io%2Fpublic-ws#/explorer){target=_blank} |
+    | Polkadot.js | Substrate | [https://polkadot.js.org/apps/#/explorer](https://polkadot.js.org/apps/?rpc=wss://wss.api.moonriver.moonbeam.network#/explorer){target=_blank} |
 
 === "Moonbase Alpha"
     | 区块浏览器  |   类型    |                                                                         URL                                                                         |
@@ -24,7 +24,7 @@
     | Blockscout  |    EVM    |            [https://moonbase-blockscout.testnet.moonbeam.network/](https://moonbase-blockscout.testnet.moonbeam.network/){target=_blank}            |
     | Expedition  |    EVM    |     [https://moonbeam-explorer.netlify.app/?network=MoonbaseAlpha](https://moonbeam-explorer.netlify.app/?network=MoonbaseAlpha){target=_blank}     |
     |   Subscan   | Substrate |                                     [https://moonbase.subscan.io/](https://moonbase.subscan.io/){target=_blank}                                     |
-    | Polkadot.js | Substrate | [https://polkadot.js.org/apps/#/explorer](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fwss.api.moonbase.moonbeam.network#/explorer){target=_blank} |
+    | Polkadot.js | Substrate | [https://polkadot.js.org/apps/#/explorer](https://polkadot.js.org/apps/?rpc=wss://wss.api.moonbase.moonbeam.network#/explorer){target=_blank} |
 
 === "Moonbeam开发节点"
     | 区块浏览器  |   类型    |                                                                       URL                                                                       |

--- a/builders/get-started/explorers.md
+++ b/builders/get-started/explorers.md
@@ -69,7 +69,7 @@ Blockscout还提供以下功能：
 
 ### Polkadot.js {: #polkadotjs } 
 
-虽然Polkadot.js Apps不是功能齐全的区块浏览器，但是一个方便的选项，尤其是对于运行本地开发节点的用户，使其可以查看事件和查询交易哈希。Polkadot.js Apps使用WebSocket端点与网络进行交互。Polkadot.js Apps支持[Moonbeam](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fwss.api.moonbeam.network#/explorer){target=_blank}、[Moonriver](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fwss.api.moonriver.moonbase.moonbeam.network#/explorer){target=_blank}和[Moonbase Alpha](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fwss.api.moonbase.moonbeam.network#/explorer){target=_blank}。
+虽然Polkadot.js Apps不是功能齐全的区块浏览器，但是一个方便的选项，尤其是对于运行本地开发节点的用户，使其可以查看事件和查询交易哈希。Polkadot.js Apps使用WebSocket端点与网络进行交互。Polkadot.js Apps支持[Moonbeam](https://polkadot.js.org/apps/?rpc=wss://wss.api.moonbeam.network#/explorer){target=_blank}、[Moonriver](https://polkadot.js.org/apps/?rpc=wss://wss.api.moonriver.moonbase.moonbeam.network#/explorer){target=_blank}和[Moonbase Alpha](https://polkadot.js.org/apps/?rpc=wss://wss.api.moonbase.moonbeam.network#/explorer){target=_blank}。
 
 ![Polkadot.js Moonriver](/images/builders/get-started/explorers/explorers-5.png)
 

--- a/builders/get-started/networks/moonbase.md
+++ b/builders/get-started/networks/moonbase.md
@@ -14,7 +14,7 @@ description: Moonbeam测试网（Moonbase Alpha）是进入波卡（Polkadot）�
  - **Ethereum API（等同于Etherscan）** —— [Moonscan](https://moonbase.moonscan.io/){target=_blank}
  - **带索引的Ethereum API** —— [Blockscout](https://moonbase-blockscout.testnet.moonbeam.network/){target=_blank}
  - **基于Ethereum API JSON-RPC** —— [Moonbeam Basic Explorer](https://moonbeam-explorer.netlify.app/?network=MoonbaseAlpha){target=_blank}
- - **Substrate API** —— [Subscan](https://moonbase.subscan.io/){target=_blank}或[Polkadot.js Apps](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fwss.api.moonbase.moonbeam.network#/explorer){target=_blank}
+ - **Substrate API** —— [Subscan](https://moonbase.subscan.io/){target=_blank}或[Polkadot.js Apps](https://polkadot.js.org/apps/?rpc=wss://wss.api.moonbase.moonbeam.network#/explorer){target=_blank}
 
 更多关于上述区块浏览器的信息，请直接查看[区块浏览器](/builders/get-started/explorers/){target=_blank} 部分。
 

--- a/builders/get-started/networks/moonbeam.md
+++ b/builders/get-started/networks/moonbeam.md
@@ -14,7 +14,7 @@ description: 学习如何通过RPC和WSS端点快速连接至基于波卡的Moon
  - **以太坊API（类似Etherscan）**—— [Moonscan](https://moonbeam.moonscan.io/)
  - **具有索引功能的以太坊API** —— [Blockscout](https://blockscout.moonbeam.network/)
  - **基于以太坊API JSON-RPC** —— [Moonbeam Basic Explorer](https://moonbeam-explorer.netlify.app/?network=Moonbeam)
- - **Substrate API** —— [Subscan](https://moonbeam.subscan.io/)或[Polkadot.js Apps](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fwss.api.moonbeam.network#/explorer)
+ - **Substrate API** —— [Subscan](https://moonbeam.subscan.io/)或[Polkadot.js Apps](https://polkadot.js.org/apps/?rpc=wss://wss.api.moonbeam.network#/explorer)
 
 更多可用区块浏览器的相关信息，请访问Moonbeam资料库的[区块浏览器](/builders/get-started/explorers/)部分。
 

--- a/builders/get-started/networks/moonriver.md
+++ b/builders/get-started/networks/moonriver.md
@@ -14,7 +14,7 @@ description: 学习如何通过RPC和WSS端点连接到Moonriver网络 - Moonbea
  - **以太坊API(类似Etherscan)** — [Moonscan](https://moonriver.moonscan.io/){target=_blank}
  - **基于以太坊API和索引** — [Blockscout](https://blockscout.moonriver.moonbeam.network/){target=_blank}
  - **基于以太坊API JSON-RPC** — [Moonbeam Basic Explorer](https://moonbeam-explorer.netlify.app/?network=Moonriver){target=_blank}
- - **基于Substrate API** — [Subscan](https://moonriver.subscan.io/)或[Polkadot.js Apps](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fwss.api.moonriver.moonbeam.network#/explorer){target=_blank}
+ - **基于Substrate API** — [Subscan](https://moonriver.subscan.io/)或[Polkadot.js Apps](https://polkadot.js.org/apps/?rpc=wss://wss.api.moonriver.moonbeam.network#/explorer){target=_blank}
 
  更多相关信息请参考[区块浏览器](/builders/get-started/explorers/){target=_blank}文档。
 

--- a/builders/integrations/indexers/subquery.md
+++ b/builders/integrations/indexers/subquery.md
@@ -94,13 +94,15 @@ SubQuery支持索引任意Moonbeam网络的以太坊虚拟机（EVM）和Substra
 
 您将需要在`project.yaml`文件中更新`network`配置。`chainId`字段处可用于输入您想要索引的网络创世哈希。
 
+ --8<-- 'text/common/endpoint-examples.md'
+
 每个网络的`network`配置如下所示：
 
 === "Moonbeam"
     ```
     network:
     chainId: '0xfe58ea77779b7abda7da4ec526d14db9b1e9cd40a217c34892af80a9b332b76d'
-    endpoint: 'https://moonbeam.api.onfinality.io/public'
+    endpoint: '{{ networks.moonbeam.rpc_url }}'
     dictionary: 'https://api.subquery.network/sq/subquery/moonbeam-dictionary'
     chaintypes:
       file: ./dist/chaintypes.js
@@ -110,7 +112,7 @@ SubQuery支持索引任意Moonbeam网络的以太坊虚拟机（EVM）和Substra
     ```yaml
     network:
     chainId: '0x401a1f9dca3da46f5c4091016c8a2f26dcea05865116b286f60f668207d1474b'
-    endpoint: 'https://moonriver.api.onfinality.io/public'
+    endpoint: '{{ networks.moonriver.rpc_url }}'
     dictionary: 'https://api.subquery.network/sq/subquery/moonriver-dictionary'
     chaintypes:
       file: ./dist/chaintypes.js
@@ -120,7 +122,7 @@ SubQuery支持索引任意Moonbeam网络的以太坊虚拟机（EVM）和Substra
     ```
     network:
     chainId: '0x91bc6e169807aaa54802737e1c504b2577d4fafedd5a02c10293b1cd60e39527'
-    endpoint: 'https://moonbeam-alpha.api.onfinality.io/public'
+    endpoint: '{{ networks.moonbase.rpc_url }}'
     dictionary: 'https://api.subquery.network/sq/subquery/moonbase-alpha-dictionary'
     chaintypes:
       file: ./dist/chaintypes.js    

--- a/builders/interoperability/xcm/fees.md
+++ b/builders/interoperability/xcm/fees.md
@@ -250,7 +250,7 @@ XCM-GLMR-Cost = {{ networks.moonbeam.xcm.instructions.wei_cost }} / (10^18)
 
 考虑Alice在Moonbeam上向Alith的账户发送DOT的场景，费用从Alith收到的xcDOT金额中收取。要确定支付多少费用，Moonbeam使用了一个名为`UnitsPerSecond`的概念，代表网络在XCM执行时间内每秒收取的Token单位（包含小数）。 Moonbeam（可能还有其他平行链）将使用此概念来确定使用与其储备不同的资产执行XCM的费用。
 
-此外，在Moonbeam上执行XCM可以由原本资产来源链的多种资产（[XC-20s](/builders/interoperability/xcm/xc20/overview/){target=_blank}）支付。举例来说，在撰写本文时，从[Statemine](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fstatemine-rpc.polkadot.io#/explorer)发送的XCM消息{target=_blank}可以用xcKSM、xcRMRK 或xcUSDT支付。只要该资产在Moonbeam/Moonriver中设置了`UnitsPerSecond`，它就可以用于为来自该特定链的XCM消息支付XCM执行费用。
+此外，在Moonbeam上执行XCM可以由原本资产来源链的多种资产（[XC-20s](/builders/interoperability/xcm/xc20/overview/){target=_blank}）支付。举例来说，在撰写本文时，从[Statemine](https://polkadot.js.org/apps/?rpc=wss://statemine-rpc.polkadot.io#/explorer)发送的XCM消息{target=_blank}可以用xcKSM、xcRMRK 或xcUSDT支付。只要该资产在Moonbeam/Moonriver中设置了`UnitsPerSecond`，它就可以用于为来自该特定链的XCM消息支付XCM执行费用。
 
 要找出给定的资产是否在`UnitsPerSecond`列表中，您可以使用`assetManager.assetTypeUnitsPerSecond`函数并输入想要查看的资产的multilocation。
 
@@ -334,7 +334,7 @@ Alice转移DOT至Alith账户的总花费为`{{ networks.moonbeam.xcm.message.tra
 
 在[通过主权衍生账户进行交易](/builders/interoperability/xcm/xcm-transactor/#xcmtransactor-transact-through-derivative){target=_blank}时，交易费用由原链的主权账户支付目标链，但由衍生账户调度。因此，XCM交易者pallet将销毁一定数量的相应XC-20 Token，以释放主权账户中的一些余额用于支付XCM执行费。
 
-您可以想像以下情景：Alice想要从Moonbeam使用通过主权extrinsic在波卡中进行远程交易（她已经在她的账户中注册了一个索引）。要预估从Alice的账户中将销毁多少XC-20 Token，您需要检查特定于中继链的交易信息。因此，请前往[Polkadot.js Apps](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fwss.api.moonbeam.network#/chainstate){target=_blank}的链状态页面并设置以下选项：
+您可以想像以下情景：Alice想要从Moonbeam使用通过主权extrinsic在波卡中进行远程交易（她已经在她的账户中注册了一个索引）。要预估从Alice的账户中将销毁多少XC-20 Token，您需要检查特定于中继链的交易信息。因此，请前往[Polkadot.js Apps](https://polkadot.js.org/apps/?rpc=wss://wss.api.moonbeam.network#/chainstate){target=_blank}的链状态页面并设置以下选项：
 
 1. 选取**xcmTransactor** pallet
 2. 选取**transactInfoWithWeightLimit**方法
@@ -344,7 +344,7 @@ Alice转移DOT至Alith账户的总花费为`{{ networks.moonbeam.xcm.message.tra
 
 ![Get the Transact Through Derivative Weight Info for Polkadot](/images/builders/interoperability/xcm/fees/fees-3.png)
 
-在获得的回应中，您可以看到`transactExtraWeight`为`{{ networks.polkadot.xcm_message.transact.weight }}`。这是在该特定目标链中执行此远程调用的三个XCM指令所需的权重。接下来，您需要找到该特定链的`UnitsPerSecond`。在同一个[Polkadot.js Apps页面](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fwss.api.moonbeam.network#/chainstate){target=_blank}，设置以下选项：
+在获得的回应中，您可以看到`transactExtraWeight`为`{{ networks.polkadot.xcm_message.transact.weight }}`。这是在该特定目标链中执行此远程调用的三个XCM指令所需的权重。接下来，您需要找到该特定链的`UnitsPerSecond`。在同一个[Polkadot.js Apps页面](https://polkadot.js.org/apps/?rpc=wss://wss.api.moonbeam.network#/chainstate){target=_blank}，设置以下选项：
 
 1. 选取**xcmTransactor**pallet
 2. 选取**destinationAssetFeePerSecond**函数
@@ -376,7 +376,7 @@ XCM-DOT-Cost = {{ networks.polkadot.xcm_message.transact.planck_dot_cost }} / 10
 
 在[通过multilocation衍生账户进行交易](/builders/interoperability/xcm/xcm-transactor/#xcmtransactor-transact-through-derivative){target=_blank}时，交易费用由发出调用的同一账户支付，其为目标链中的multilocation衍生帐户。因此，multilocation衍生帐户必须持有必要的资金来支付整个执行费用。请注意，支付费用的目标Token不需要在原链中注册为XC-20。
 
-您可以想像以下情景：Alice想要使用通过签名函数的交易从Moonbase Alpha在另一条链（平行链 ID 888，在Moonbase Alpha中继链生态系统中）进行远程交易。要估计Alice的multilocation衍生账户执行远程调用所需的Token数量，您需要检查在目标链的特定交易信息。为此，请前往[Polkadot.js Apps](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fwss.api.moonbeam.network#/chainstate){target=_blank}的链状态页面并设置以下选项：
+您可以想像以下情景：Alice想要使用通过签名函数的交易从Moonbase Alpha在另一条链（平行链 ID 888，在Moonbase Alpha中继链生态系统中）进行远程交易。要估计Alice的multilocation衍生账户执行远程调用所需的Token数量，您需要检查在目标链的特定交易信息。为此，请前往[Polkadot.js Apps](https://polkadot.js.org/apps/?rpc=wss://wss.api.moonbeam.network#/chainstate){target=_blank}的链状态页面并设置以下选项：
 
 
 1. 选取**xcmTransactor** pallet
@@ -389,7 +389,7 @@ XCM-DOT-Cost = {{ networks.polkadot.xcm_message.transact.planck_dot_cost }} / 10
 
 ![Get the Transact Through Derivative Weight Info for another Parachain](/images/builders/interoperability/xcm/fees/fees-5.png)
 
-在获得的回应中，您可以看到`transactExtraWeightSigned`为`{{ networks.moonbase_beta.xcm_message.transact.weight }}`。这是在该特定目标链中执行此远程调用的4个XCM指令所需的权重。接下来，您需要找到目标链每执行XCM权重收取的费用。通常，您会查看该特定链的`UnitsPerSecond`。但在这种情况下并不会销毁XC-20 Token。因此，`UnitsPerSecond`可以作为参考，但不能保证估算的Token数量是正确的。要获取`UnitsPerSecond`作为参考值，在同一个[Polkadot.js Apps页面](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fwss.api.moonbeam.network #/chainstate){target=_blank}，设置以下选项：
+在获得的回应中，您可以看到`transactExtraWeightSigned`为`{{ networks.moonbase_beta.xcm_message.transact.weight }}`。这是在该特定目标链中执行此远程调用的4个XCM指令所需的权重。接下来，您需要找到目标链每执行XCM权重收取的费用。通常，您会查看该特定链的`UnitsPerSecond`。但在这种情况下并不会销毁XC-20 Token。因此，`UnitsPerSecond`可以作为参考，但不能保证估算的Token数量是正确的。要获取`UnitsPerSecond`作为参考值，在同一个[Polkadot.js Apps页面](https://polkadot.js.org/apps/?rpc=wss://wss.api.moonbeam.network #/chainstate){target=_blank}，设置以下选项：
 
 1. 选取**xcmTransactor** pallet
 2. 选取**destinationAssetFeePerSecond**方法

--- a/builders/interoperability/xcm/remote-evm-calls.md
+++ b/builders/interoperability/xcm/remote-evm-calls.md
@@ -93,7 +93,7 @@ Ethereum-XCM pallet提供以下extrinsics（函数），可以通过`Transact`�
 
 为了能够从中继链在Polkadot.js应用程序中发送调用请求，您需要具备以下条件：
 
- - 一个在中继链上拥有资金（`UNIT`）的[账户](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Ffrag-moonbase-relay-rpc-ws.g.moonbase.moonbeam.network#/accounts){target=_blank}以支付交易费用。您可以通过在[Moonbeam-Swap](https://moonbeam-swap.netlify.app){target=_blank}上交换DEV Token（Moonbase Alpha的原生Token）来获得一些`xcUNIT`，此为先前在Moonbase Alpha演示的克隆Uniswap-V2。接着[将它们发送到中继链](/builders/interoperability/xcm/xc20/xtokens/){target=_blank}。此外，您也可以[联系我们](https://discord.gg/PfpUATX){target=_blank}直接获取一些`UNIT` Token
+ - 一个在中继链上拥有资金（`UNIT`）的[账户](https://polkadot.js.org/apps/?rpc=wss://frag-moonbase-relay-rpc-ws.g.moonbase.moonbeam.network#/accounts){target=_blank}以支付交易费用。您可以通过在[Moonbeam-Swap](https://moonbeam-swap.netlify.app){target=_blank}上交换DEV Token（Moonbase Alpha的原生Token）来获得一些`xcUNIT`，此为先前在Moonbase Alpha演示的克隆Uniswap-V2。接着[将它们发送到中继链](/builders/interoperability/xcm/xc20/xtokens/){target=_blank}。此外，您也可以[联系我们](https://discord.gg/PfpUATX){target=_blank}直接获取一些`UNIT` Token
  - 为**multilocation衍生账户**提供资金，您可以按照[下一部分](#calculate-multilocation-derivative){target=_blank}中的步骤获得该账户。该账户必须有足够的DEV Token（或Moonbeam/Moonriver网络中的GLMR/MOVR）来支付远程EVM调用的XCM执行成本。请注意，此衍生账户是将发送远程EVM调用的帐户（`msg.sender`）。因此，帐户必须满足正确执行EVM调用所需的任何条件。例如，如果您正在执行ERC-20转账，请确保拥有任何相关的ERC-20 Token
 
 !!! 注意事项
@@ -175,7 +175,7 @@ ts-node calculateMultilocationDerivative.ts \
 
 与`increment`函数交互的编码调用数据为`0xd09de08a`，即`increment()`的keccak256哈希的前8个十六进制字符（或4个字节）。如果函数有输入参数，它们也需要编码。获取编码调用数据最简单的方法是在[Remix](/builders/build/eth-api/dev-env/remix/#interacting-with-a-moonbeam-based-erc-20-from-metamask){target=_blank}或[Moonscan](https://moonbase.moonscan.io/address/0xa72f549a1a12b9b49f30a7f3aeb1f4e96389c5d8#code){target=_blank}进行模拟交易。接下来，在MetaMask 中，在签名之前检查**HEX**标签下的**HEX DATA: 4 BYTES**选择器。您无需签署交易。
 
-通过合约交互数据，您可以为[Ethereum-XCM pallet](https://github.com/PureStake/moonbeam/tree/master/pallets/ethereum-xcm){target=_blank}调用构建编码调用数据。为此，请前往[Polkadot.js Apps](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fwss.api.moonbase.moonbeam.network#/extrinsics){target=_blank}的extrinsics页面并跟随步骤设置以下选项（请注意，extrinsics页面仅将在您拥有帐户时显示）：
+通过合约交互数据，您可以为[Ethereum-XCM pallet](https://github.com/PureStake/moonbeam/tree/master/pallets/ethereum-xcm){target=_blank}调用构建编码调用数据。为此，请前往[Polkadot.js Apps](https://polkadot.js.org/apps/?rpc=wss://wss.api.moonbase.moonbeam.network#/extrinsics){target=_blank}的extrinsics页面并跟随步骤设置以下选项（请注意，extrinsics页面仅将在您拥有帐户时显示）：
 
 !!! 注意事项
     [Ethereum-XCM pallet](https://github.com/PureStake/moonbeam/tree/master/pallets/ethereum-xcm){target=_blank}当前实现不支持`CREATE`操作。因此，您无法通过远程EVM调用部署智能合约。
@@ -199,7 +199,7 @@ ts-node calculateMultilocationDerivative.ts \
 
 在本示例中，您将构建一条XCM消息，通过[`Transact`](https://github.com/paritytech/xcm-format#transact){target=_blank} XCM指令和[Ethereum-XCM pallet](https://github.com/PureStake/moonbeam/tree/master/pallets/ethereum-xcm){target=_blank}的`transact`函数从其中继链在Moonbase Alpha种执行远程EVM调用。
 
-如果您已经[检查了先决条件](#ethereumxcm-check-prerequisites)并且已有[Ethereum-XCM pallet](https://github.com/PureStake/moonbeam/tree/master/pallets/ethereum-xcm){target=_blank}的[编码调用数据](#ethereumxcm-transact-data)，请导向至[Polkadot.js Apps](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Ffrag-moonbase-relay-rpc-ws.g.moonbase.moonbeam.network#/extrinsics){target=_blank}的extrinsics页面并设置以下选项：
+如果您已经[检查了先决条件](#ethereumxcm-check-prerequisites)并且已有[Ethereum-XCM pallet](https://github.com/PureStake/moonbeam/tree/master/pallets/ethereum-xcm){target=_blank}的[编码调用数据](#ethereumxcm-transact-data)，请导向至[Polkadot.js Apps](https://polkadot.js.org/apps/?rpc=wss://frag-moonbase-relay-rpc-ws.g.moonbase.moonbeam.network#/extrinsics){target=_blank}的extrinsics页面并设置以下选项：
 
 1. 选取您希望传送XCM的账户。确认账户符合所有[先决条件](#ethereumxcm-check-prerequisites)
 2. 选取**xcmPallet** pallet
@@ -276,7 +276,7 @@ ts-node calculateMultilocationDerivative.ts \
 
 ![Remote XCM Call from Relay Chain](/images/builders/interoperability/xcm/remote-evm-calls/xcmevm-3.png)
 
-一旦交易处理完毕，您可以在[中继链](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Ffrag-moonbase-relay-rpc-ws.g.moonbase.moonbeam.network#/explorer/query/0x2a0e40a2e5261e792190826ce338ed513fe44dec16dd416a12f547d358773f98){target=_blank}和[Moonbase Alpha](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fwss.api.moonbase.moonbeam.network#/explorer/query/0x7570d6fa34b9dccd8b8839c2986260034eafef732bbc09f8ae5f857c28765145){target=_blank}查看相关extrinsics和事件。
+一旦交易处理完毕，您可以在[中继链](https://polkadot.js.org/apps/?rpc=wss://frag-moonbase-relay-rpc-ws.g.moonbase.moonbeam.network#/explorer/query/0x2a0e40a2e5261e792190826ce338ed513fe44dec16dd416a12f547d358773f98){target=_blank}和[Moonbase Alpha](https://polkadot.js.org/apps/?rpc=wss://wss.api.moonbase.moonbeam.network#/explorer/query/0x7570d6fa34b9dccd8b8839c2986260034eafef732bbc09f8ae5f857c28765145){target=_blank}查看相关extrinsics和事件。
 
 在中继链中，extrinsic为`xcmPallet.send`，关联事件为`xcmPallet.Sent`（其中与费用有关）。在Moonbase Alpha中，XCM执行在`parachainSystem.setValidationData`函数发生，并且可以注意多个关联事件：
 

--- a/builders/interoperability/xcm/xc-integration.md
+++ b/builders/interoperability/xcm/xc-integration.md
@@ -84,7 +84,7 @@ Moonriver/Moonbeam XCM集成的第一步是通过Alphanet中继链与Moonbase Al
 您需要准备以下内容：
 
 - Genesis head/wasm hash
-- 平行链ID。您可以在[中继链Polkadot.js Apps页面](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Ffrag-moonbase-relay-rpc-ws.g.moonbase.moonbeam.network#/parachains){target=_blank}找到所需的平行链ID
+- 平行链ID。您可以在[中继链Polkadot.js Apps页面](https://polkadot.js.org/apps/?rpc=wss://frag-moonbase-relay-rpc-ws.g.moonbase.moonbeam.network#/parachains){target=_blank}找到所需的平行链ID
 
 [此处有一些Alphanet生态系统中继链的快照](http://snapshots.moonbeam.network.s3-website.us-east-2.amazonaws.com/){target=_blank}可供您使用以快速开始操作。
 
@@ -119,7 +119,7 @@ Sovereign Account Address on Moonbase Alpha: 0x7369626ce803000000000000000000000
 
 ### 获取中继链编码调用数据 {: #get-the-relay-chain-encoded-call-data }
 
-要获取在第三步执行的调用数据，您可前往Polkdot.js Apps并连接至[Moonbase Alpha中继链](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Ffrag-moonbase-relay-rpc-ws.g.moonbase.moonbeam.network#/extrinsics){target=_blank}、[Kusama](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fkusama.api.onfinality.io%2Fpublic-ws#/extrinsics){target=_blank}或[Polkadot](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fpolkadot.api.onfinality.io%2Fpublic-ws#/extrinsics){target=_blank}的WSS端点。导向**Developer**标签，选择**Extrinsics**，并执行以下步骤：
+要获取在第三步执行的调用数据，您可前往Polkdot.js Apps并连接至[Moonbase Alpha中继链](https://polkadot.js.org/apps/?rpc=wss://frag-moonbase-relay-rpc-ws.g.moonbase.moonbeam.network#/extrinsics){target=_blank}、[Kusama](https://polkadot.js.org/apps/?rpc=wss://kusama.api.onfinality.io%2Fpublic-ws#/extrinsics){target=_blank}或[Polkadot](https://polkadot.js.org/apps/?rpc=wss://polkadot.api.onfinality.io%2Fpublic-ws#/extrinsics){target=_blank}的WSS端点。导向**Developer**标签，选择**Extrinsics**，并执行以下步骤：
 
 1. 在**submit the following extrinsic**下拉菜单中选择**hrmp**
 2. 选择**hrmpInitOpenChannel** extrinsic
@@ -271,7 +271,7 @@ Sovereign Account Address on Moonbase Alpha: 0x7369626ce803000000000000000000000
 
 ### 获取中继链编码调用数据 {: #get-the-relay-chain-encoded-call-data }
 
-要获取在第三步执行的调用数据，您可前往Polkdot.js Apps并连接至[Moonbase Alpha中继链](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Ffrag-moonbase-relay-rpc-ws.g.moonbase.moonbeam.network#/extrinsics){target=_blank}、[Kusama](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fkusama.api.onfinality.io%2Fpublic-ws#/extrinsics){target=_blank}或[Polkadot](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fpolkadot.api.onfinality.io%2Fpublic-ws#/extrinsics){target=_blank}的WSS端点。导向**Developer**标签，选择**Extrinsics**，并执行以下步骤：
+要获取在第三步执行的调用数据，您可前往Polkdot.js Apps并连接至[Moonbase Alpha中继链](https://polkadot.js.org/apps/?rpc=wss://frag-moonbase-relay-rpc-ws.g.moonbase.moonbeam.network#/extrinsics){target=_blank}、[Kusama](https://polkadot.js.org/apps/?rpc=wss://kusama.api.onfinality.io%2Fpublic-ws#/extrinsics){target=_blank}或[Polkadot](https://polkadot.js.org/apps/?rpc=wss://polkadot.api.onfinality.io%2Fpublic-ws#/extrinsics){target=_blank}的WSS端点。导向**Developer**标签，选择**Extrinsics**，并执行以下步骤：
 
 1. 在**submit the following extrinsic**下拉菜单中选择**hrmp**
 2. 选择**hrmpAcceptOpenChannel** extrinsic

--- a/builders/interoperability/xcm/xc20/mintable-xc20.md
+++ b/builders/interoperability/xcm/xc20/mintable-xc20.md
@@ -52,7 +52,7 @@ description: 学习如何在基于Moonbeam网络铸造和销毁以及通过XCM�
 
 ## 获取可铸造XC-20资产的列表 {: #retrieve-list-of-mintable-xc-20s }
 
-要获取Moonbase Alpha测试网上目前可用的可铸造XC-20资产列表，请导向至[Polkadot.js Apps](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fwss.api.moonbase.moonbeam.network#/explorer){target=_blank}并确保您已连接至Moonbase Alpha。不同于外部XC-20资产，可铸造XC-20资产并不会在**Assets**栏位下出现。要查询可用的可铸造XC-20资产，您需要导向至**Developer**标签，并在下拉菜单中选择**Chain State**，然后跟随以下步骤：
+要获取Moonbase Alpha测试网上目前可用的可铸造XC-20资产列表，请导向至[Polkadot.js Apps](https://polkadot.js.org/apps/?rpc=wss://wss.api.moonbase.moonbeam.network#/explorer){target=_blank}并确保您已连接至Moonbase Alpha。不同于外部XC-20资产，可铸造XC-20资产并不会在**Assets**栏位下出现。要查询可用的可铸造XC-20资产，您需要导向至**Developer**标签，并在下拉菜单中选择**Chain State**，然后跟随以下步骤：
 
 1.   在**selected state query**下拉菜单中，选择**localAssets**
 --8<-- 'text/xc-20/list-of-assets.md'
@@ -92,7 +92,7 @@ address = "0xFFFFFFFE..." + DecimalToHex(AssetId)
 
 ## 注册一个可铸造XC-20资产 {: #register-a-mxc-20 }
 
-这一部分将会引导您如何在[Polkadot.js Apps](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fwss.api.moonbase.moonbeam.network#/explorer){target=_blank}注册一个资产并使用[Remix](https://remix.ethereum.org/){target=_blank}与可铸造XC-20资产特定的函数交互。如果您仅想通过标准ERC-20接口与可铸造XC-20资产交互，请查看XC-20预编译页面的[如何使用Remix与预编译合约交互](/builders/interoperability/xcm/xc20/overview/#interact-with-the-precompile-using-remix){target=_blank}部分。
+这一部分将会引导您如何在[Polkadot.js Apps](https://polkadot.js.org/apps/?rpc=wss://wss.api.moonbase.moonbeam.network#/explorer){target=_blank}注册一个资产并使用[Remix](https://remix.ethereum.org/){target=_blank}与可铸造XC-20资产特定的函数交互。如果您仅想通过标准ERC-20接口与可铸造XC-20资产交互，请查看XC-20预编译页面的[如何使用Remix与预编译合约交互](/builders/interoperability/xcm/xc20/overview/#interact-with-the-precompile-using-remix){target=_blank}部分。
 
 ### 查看先决条件 {: #checking-prerequisites }
 
@@ -121,7 +121,7 @@ address = "0xFFFFFFFE..." + DecimalToHex(AssetId)
     {{ networks.moonbase.mintable_xc20.asset_deposit }} DEV
     ```
 
-接着，导向至[Polkadot.js Apps](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fwss.api.moonbase.moonbeam.network#/explorer){target=_blank}并确保您已连接至Moonbase Alpha。在网页最上方点击**Governance**并在下拉菜单中选择**Democracy**。接着，选择**+ Submit preimage**并跟随以下步骤进行操作：
+接着，导向至[Polkadot.js Apps](https://polkadot.js.org/apps/?rpc=wss://wss.api.moonbase.moonbeam.network#/explorer){target=_blank}并确保您已连接至Moonbase Alpha。在网页最上方点击**Governance**并在下拉菜单中选择**Democracy**。接着，选择**+ Submit preimage**并跟随以下步骤进行操作：
 
 1. 选择您希望用于创建提案所要用的账户
 2. 在**propose**下拉菜单中选择**assetManager**

--- a/builders/interoperability/xcm/xc20/xc20.md
+++ b/builders/interoperability/xcm/xc20/xc20.md
@@ -37,7 +37,7 @@ description: 学习如何使用预编译的资产Solidity合约通过ERC-20接�
     |   Phala   |     xcPHA     | [0xFFFfFfFf63d24eCc8eB8a7b5D0803e900F7b6cED](https://moonscan.io/token/0xFFFfFfFf63d24eCc8eB8a7b5D0803e900F7b6cED){target=_blank} |
     | Statemint |    xcUSDT     | [0xFFFFFFfFea09FB06d082fd1275CD48b191cbCD1d](https://moonscan.io/token/0xFFFFFFfFea09FB06d082fd1275CD48b191cbCD1d){target=_blank} |
 
-     _*您可以在Polkadot.js Apps上查询[资产ID](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fwss.api.moonbeam.network#/assets){target=_blank}_
+     _*您可以在Polkadot.js Apps上查询[资产ID](https://polkadot.js.org/apps/?rpc=wss://wss.api.moonbeam.network#/assets){target=_blank}_
 
 === "Moonriver"
     |   原始网络   | XC-20表现形式 |                                                                  XC-20地址                                                                  |
@@ -59,7 +59,7 @@ description: 学习如何使用预编译的资产Solidity合约通过ERC-20接�
     |  Statemine   |    xcRMRK     | [0xffffffFF893264794d9d57E1E0E21E0042aF5A0A](https://moonriver.moonscan.io/token/0xffffffFF893264794d9d57E1E0E21E0042aF5A0A){target=_blank} |
     |  Statemine   |    xcUSDT     | [0xFFFFFFfFea09FB06d082fd1275CD48b191cbCD1d](https://moonriver.moonscan.io/token/0xFFFFFFfFea09FB06d082fd1275CD48b191cbCD1d){target=_blank} |
 
-    _*您可以在Polkadot.js Apps上查询[资产ID](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fwss.api.moonriver.moonbeam.network#/assets){target=_blank}_
+    _*您可以在Polkadot.js Apps上查询[资产ID](https://polkadot.js.org/apps/?rpc=wss://wss.api.moonriver.moonbeam.network#/assets){target=_blank}_
 
 === "Moonbase Alpha"
     |       原始网络        | XC-20表现形式 |                                                                 XC-20地址                                                                  |
@@ -75,11 +75,11 @@ description: 学习如何使用预编译的资产Solidity合约通过ERC-20接�
     |   Pangolin Alphanet   |   xcPARING    | [0xFFFffFfF8283448b3cB519Ca4732F2ddDC6A6165](https://moonbase.moonscan.io/token/0xFFFffFfF8283448b3cB519Ca4732F2ddDC6A6165){target=_blank} |
     |  Statemine Alphanet   |     xcTT1     | [0xfFffFfFf75976211C786fe4d73d2477e222786Ac](https://moonbase.moonscan.io/token/0xfFffFfFf75976211C786fe4d73d2477e222786Ac){target=_blank} |
 
-     _*您可以在Polkadot.js Apps上查询[资产ID](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fwss.api.moonbase.moonbeam.network#/assets){target=_blank}_
+     _*您可以在Polkadot.js Apps上查询[资产ID](https://polkadot.js.org/apps/?rpc=wss://wss.api.moonbase.moonbeam.network#/assets){target=_blank}_
 
 ## 获取外部XC-20资产的列表 {: #list-xchain-assets }
 
-要获取Moonbase Alpha测试网上目前可用的外部XC-20资产列表，请导向至[Polkadot.js Apps](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fwss.api.moonbase.moonbeam.network#/explorer){target=_blank}并确保您已连接至Moonbase Alpha。进入页面后，点击**Developer**标签并在下拉菜单中选择**Chain State**。接着，您可以跟随以下步骤查询可用的外部XC-20资产：
+要获取Moonbase Alpha测试网上目前可用的外部XC-20资产列表，请导向至[Polkadot.js Apps](https://polkadot.js.org/apps/?rpc=wss://wss.api.moonbase.moonbeam.network#/explorer){target=_blank}并确保您已连接至Moonbase Alpha。进入页面后，点击**Developer**标签并在下拉菜单中选择**Chain State**。接着，您可以跟随以下步骤查询可用的外部XC-20资产：
 
 1. 在**selected state query**下拉菜单中，选择**assets**
 

--- a/builders/interoperability/xcm/xc20/xtokens.md
+++ b/builders/interoperability/xcm/xc20/xtokens.md
@@ -71,9 +71,9 @@ X-tokens pallet包括以下用于获取pallet常量的只读函数：
 
 要在Polikadot.js Apps上发送extrinsics，您需要准备以下内容：
 
-- 一个[已添加至Polkadot.js的账户](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fwss.api.moonbase.moonbeam.network#/accounts){target=_blank}，且该账户拥有一些[DEV tokens](/builders/get-started/networks/moonbase/#get-tokens){target=_blank}
+- 一个[已添加至Polkadot.js的账户](https://polkadot.js.org/apps/?rpc=wss://wss.api.moonbase.moonbeam.network#/accounts){target=_blank}，且该账户拥有一些[DEV tokens](/builders/get-started/networks/moonbase/#get-tokens){target=_blank}
 - 您要转移资产的资产ID：
-    - 对于外部XC-20，您可以从[Polkadot.js Apps的资产ID列表](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fwss.api.moonbase.moonbeam.network#/assets){target=_blank}中获取
+    - 对于外部XC-20，您可以从[Polkadot.js Apps的资产ID列表](https://polkadot.js.org/apps/?rpc=wss://wss.api.moonbase.moonbeam.network#/assets){target=_blank}中获取
     - 对于可铸造XC-20，请查阅[获取可铸造XC-20资产的列表](/builders/interoperability/xcm/xc20/mintable-xc20/#retrieve-list-of-mintable-xc-20s){target=_blank}部分
 - 您要转移资产的位数：
     - 对于外部XC-20，请查阅[获取外部XC-20资产的元数据](/builders/interoperability/xcm/xc20/xc20/#x-chain-assets-metadata){target=_blank}部分
@@ -95,9 +95,9 @@ X-tokens pallet包括以下用于获取pallet常量的只读函数：
 
 ###  X-Tokens转移函数 {: #xtokens-transfer-function}
 
-在本示例中，您将会构建一个XCM信息，通过x-tokens pallet的`transfer`函数将`xcUNIT`从Moonbase Alpha转移回其[中继链](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Ffrag-moonbase-relay-rpc-ws.g.moonbase.moonbeam.network#/accounts){target=_blank}上。
+在本示例中，您将会构建一个XCM信息，通过x-tokens pallet的`transfer`函数将`xcUNIT`从Moonbase Alpha转移回其[中继链](https://polkadot.js.org/apps/?rpc=wss://frag-moonbase-relay-rpc-ws.g.moonbase.moonbeam.network#/accounts){target=_blank}上。
 
-导航至[Polkadot.js Apps](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fwss.api.moonbase.moonbeam.network#/extrinsics){target=_blank}的extrinsic页面，并设定以下选项（也可以适用于[可铸造XC-20s](/builders/interoperability/xcm/xc20/mintable-xc20/){target=_blank}）：
+导航至[Polkadot.js Apps](https://polkadot.js.org/apps/?rpc=wss://wss.api.moonbase.moonbeam.network#/extrinsics){target=_blank}的extrinsic页面，并设定以下选项（也可以适用于[可铸造XC-20s](/builders/interoperability/xcm/xc20/mintable-xc20/){target=_blank}）：
 
 1. 选取您希望转移XCM的账户
 2. 选择**xTokens** pallet
@@ -125,13 +125,13 @@ X-tokens pallet包括以下用于获取pallet常量的只读函数：
 
 ![XCM x-tokens Transfer Extrinsic](/images/builders/interoperability/xcm/xc20/xtokens/xtokens-2.png)
 
-当交易正在处理中，**TargetAccount**将会获取设定的转移数量并扣除用于在目标链上执行XCM的小额费用。在Polkadot.js Apps，您可以查看[Moonbase Alpha](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fwss.api.moonbase.moonbeam.network#/explorer/query/0xf163f304b939bc10b6d6abcd9fd12ea00b6f6cd3f12bb2a32b759b56d2f1a40d){target=_blank}以及[中继链](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Ffrag-moonbase-relay-rpc-ws.g.moonbase.moonbeam.network#/explorer/query/0x5b997e806303302007c6829ab8e5b166a8aafc6a68f10950cc5aa8c6981ea605){target=_blank}的相关extrinsics和事件。
+当交易正在处理中，**TargetAccount**将会获取设定的转移数量并扣除用于在目标链上执行XCM的小额费用。在Polkadot.js Apps，您可以查看[Moonbase Alpha](https://polkadot.js.org/apps/?rpc=wss://wss.api.moonbase.moonbeam.network#/explorer/query/0xf163f304b939bc10b6d6abcd9fd12ea00b6f6cd3f12bb2a32b759b56d2f1a40d){target=_blank}以及[中继链](https://polkadot.js.org/apps/?rpc=wss://frag-moonbase-relay-rpc-ws.g.moonbase.moonbeam.network#/explorer/query/0x5b997e806303302007c6829ab8e5b166a8aafc6a68f10950cc5aa8c6981ea605){target=_blank}的相关extrinsics和事件。
 
 ### X-Tokens转移多种资产函数 {: #xtokens-transfer-multiasset-function}
 
-在本示例中，您将会构建一个XCM信息，通过x-tokens pallet的`transferMultiasset`函数将`xcUNIT`从Moonbase Alpha转移回其[中继链](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Ffrag-moonbase-relay-rpc-ws.g.moonbase.moonbeam.network#/accounts){target=_blank}上。
+在本示例中，您将会构建一个XCM信息，通过x-tokens pallet的`transferMultiasset`函数将`xcUNIT`从Moonbase Alpha转移回其[中继链](https://polkadot.js.org/apps/?rpc=wss://frag-moonbase-relay-rpc-ws.g.moonbase.moonbeam.network#/accounts){target=_blank}上。
 
-导航至[Polkadot.js Apps](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fwss.api.moonbase.moonbeam.network#/extrinsics){target=_blank}的extrinsic页面，并设定以下选项：
+导航至[Polkadot.js Apps](https://polkadot.js.org/apps/?rpc=wss://wss.api.moonbase.moonbeam.network#/extrinsics){target=_blank}的extrinsic页面，并设定以下选项：
 
 1. 选取您希望转移XCM的账户
 
@@ -181,7 +181,7 @@ X-tokens pallet包括以下用于获取pallet常量的只读函数：
 
 ![XCM x-tokens Transfer Extrinsic](/images/builders/interoperability/xcm/xc20/xtokens/xtokens-3.png)
 
-当交易正在处理中，**TargetAccount**将会获取设定的转移数量并扣取用于在目标链上执行XCM的小额费用。在Polkadot.js Apps，您可以查看[Moonbase Alpha](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fwss.api.moonbase.moonbeam.network#/explorer/query/0xf163f304b939bc10b6d6abcd9fd12ea00b6f6cd3f12bb2a32b759b56d2f1a40d){target=_blank}以及[中继链](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Ffrag-moonbase-relay-rpc-ws.g.moonbase.moonbeam.network#/explorer/query/0x5b997e806303302007c6829ab8e5b166a8aafc6a68f10950cc5aa8c6981ea605){target=_blank}的相关extrinsics和事件。
+当交易正在处理中，**TargetAccount**将会获取设定的转移数量并扣取用于在目标链上执行XCM的小额费用。在Polkadot.js Apps，您可以查看[Moonbase Alpha](https://polkadot.js.org/apps/?rpc=wss://wss.api.moonbase.moonbeam.network#/explorer/query/0xf163f304b939bc10b6d6abcd9fd12ea00b6f6cd3f12bb2a32b759b56d2f1a40d){target=_blank}以及[中继链](https://polkadot.js.org/apps/?rpc=wss://frag-moonbase-relay-rpc-ws.g.moonbase.moonbeam.network#/explorer/query/0x5b997e806303302007c6829ab8e5b166a8aafc6a68f10950cc5aa8c6981ea605){target=_blank}的相关extrinsics和事件。
 
 ## X-Tokens预编译 {: #xtokens-precompile}
 

--- a/builders/interoperability/xcm/xcm-transactor.md
+++ b/builders/interoperability/xcm/xcm-transactor.md
@@ -104,7 +104,7 @@ XCM-Transactor Pallet包含以下只读函数以获取pallet常量：
 
 要在Polkadot.js Apps发送extrinsics，您需要准备以下内容：
 
- - 拥有[资金](/builders/get-started/networks/moonbase/#get-tokens){target=_blank}的[账户](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fwss.api.moonbase.moonbeam.network#/accounts){target=_blank}
+ - 拥有[资金](/builders/get-started/networks/moonbase/#get-tokens){target=_blank}的[账户](https://polkadot.js.org/apps/?rpc=wss://wss.api.moonbase.moonbeam.network#/accounts){target=_blank}
  - 您将要通过XCM-Transactor Pallet发送XCM的账户必须注册在给定索引中，以便能够通过主权账户的衍生账户进行操作。注册是通过根账户（Moonbase Alpha中的SUDO）完成的，所以您可以通过[联系我们](https://discord.gg/PfpUATX){target=_blank}进行注册。在本示例中，Alice的账号注册在索引`42`中
  - 通过XCM-Transactor的远程调用需要目标链的Token作为手续费才能执行。因为此操作是在Moonbeam发起，所以您将需要保留Token的[XC-20](/builders/interoperability/xcm/xc20/){target=_blank}表现形式。在本示例中，您正在发送XCM消息至中继链，因此您将需要`xcUNIT` Token（即Alphanet中继链Token `UNIT`的Moonbase Alpha表现形式）支付执行费用。您可以通过在[Moonbeam-Swap](https://moonbeam-swap.netlify.app){target=_blank}（Moonbase Alpha 上的Uniswap V2演示版本）上兑换DEV Token以获取该Token
 
@@ -124,7 +124,7 @@ XCM-Transactor Pallet包含以下只读函数以获取pallet常量：
 
 ### 构建XCM {: #xcm-transact-through-derivative }
 
-如果您已[完成准备工作](#xcmtransactor-derivative-check-prerequisites)，导向至[Polkadot.js Apps](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fwss.api.moonbase.moonbeam.network#/extrinsics){target=_blank}的extrinsic页面，执行以下操作：
+如果您已[完成准备工作](#xcmtransactor-derivative-check-prerequisites)，导向至[Polkadot.js Apps](https://polkadot.js.org/apps/?rpc=wss://wss.api.moonbase.moonbeam.network#/extrinsics){target=_blank}的extrinsic页面，执行以下操作：
 
 1. 选择您要发送XCM的账户，确保账户已[完成所有设置](#xcmtransactor-derivative-check-prerequisites)
 
@@ -144,7 +144,7 @@ XCM-Transactor Pallet包含以下只读函数以获取pallet常量：
 
 9. （可选）设置**feeAmount**。这是所选费用Token（XC-20）的每秒单位，将被销毁以释放目标链上主权账户中的相应余额。在本示例中，将每秒单位设置为`13764626000000` 。若您未提供此数值，pallet将使用存储库中的元素（若有）
 
-10. 输入将在目标链中执行的内部调用。这是pallet、方法和将被调用输入数值的编码调用数据。这可以在Polakdot.js Apps（必须连接至目标链）或使用[Polkadot.js API](/builders/build/substrate-api/polkadot-js-api/){target=_blank}构建。在本示例中，内部调用为`0x04000030fcfb53304c429689c8f94ead291272333e16d77a2560717f3a7a410be9b208070010a5d4e8`（即在中继链中将1 `UNIT`转移给Alice账户）。您可以在[Polkadot.js Apps](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Ffrag-moonbase-relay-rpc-ws.g.moonbase.moonbeam.network#/extrinsics/decode){target=_blank}中编码调用
+10. 输入将在目标链中执行的内部调用。这是pallet、方法和将被调用输入数值的编码调用数据。这可以在Polakdot.js Apps（必须连接至目标链）或使用[Polkadot.js API](/builders/build/substrate-api/polkadot-js-api/){target=_blank}构建。在本示例中，内部调用为`0x04000030fcfb53304c429689c8f94ead291272333e16d77a2560717f3a7a410be9b208070010a5d4e8`（即在中继链中将1 `UNIT`转移给Alice账户）。您可以在[Polkadot.js Apps](https://polkadot.js.org/apps/?rpc=wss://frag-moonbase-relay-rpc-ws.g.moonbase.moonbeam.network#/extrinsics/decode){target=_blank}中编码调用
 
 11. 设置**weightInfo**结构的**transactRequiredWeightAtMost**权重值。该数值必须包含`asDerivative` extrinsic。但是这不会包含XCM指令的权重。在本示例中，可以将权重设置为`1000000000`
 
@@ -157,14 +157,14 @@ XCM-Transactor Pallet包含以下只读函数以获取pallet常量：
 
 ![XCM-Transactor Transact Through Derivative Extrinsic](/images/builders/interoperability/xcm/xcm-transactor/xcmtransactor-1.png)
 
-当交易完成后，您可以在[Moonbase Alpha](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fwss.api.moonbase.moonbeam.network#/explorer/query/0xa90b23a54f2bb691ba2f04ae3228b1de2d2e7231b98490bf6f94e491baf09185){target=_blank}和[中继链](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Ffrag-moonbase-relay-rpc-ws.g.moonbase.moonbeam.network#/explorer/query/0xb5a0ecc0c2f7f1363ede2e3aebab2702dd2e7b9036a6ba23a694db2b4002cd7f){target=_blank}中查看相关extrinsic和事件。请注意，在Moonbase Alpha中，有一个`transactThroughDerivative`方法相关联的事件，但是有一些`xcUNIT` Token已被销毁以偿还主权账户的交易费用。在中继链中，`paraInherent.enter` extrinsic会显示`balance.Transfer`事件，其中1 `UNIT` Token转移给Alice地址。尽管如此，交易费仍会通过Moonbase Alpha主权账户进行支付。
+当交易完成后，您可以在[Moonbase Alpha](https://polkadot.js.org/apps/?rpc=wss://wss.api.moonbase.moonbeam.network#/explorer/query/0xa90b23a54f2bb691ba2f04ae3228b1de2d2e7231b98490bf6f94e491baf09185){target=_blank}和[中继链](https://polkadot.js.org/apps/?rpc=wss://frag-moonbase-relay-rpc-ws.g.moonbase.moonbeam.network#/explorer/query/0xb5a0ecc0c2f7f1363ede2e3aebab2702dd2e7b9036a6ba23a694db2b4002cd7f){target=_blank}中查看相关extrinsic和事件。请注意，在Moonbase Alpha中，有一个`transactThroughDerivative`方法相关联的事件，但是有一些`xcUNIT` Token已被销毁以偿还主权账户的交易费用。在中继链中，`paraInherent.enter` extrinsic会显示`balance.Transfer`事件，其中1 `UNIT` Token转移给Alice地址。尽管如此，交易费仍会通过Moonbase Alpha主权账户进行支付。
 
 !!! 注意事项
     `AssetsTrapped`事件在中继链上时因为XCM-Transactor Pallet尚不支持处理还款功能。因此，高出预估权重将会在目标链执行XCM时导致资产无法退回。
 
 ### 获取已注册的衍生索引 {: #retrieve-registered-derivative-indexes }
 
-要获取所有基于Moonbeam网络主权账户和其对应索引操作的注册地址列表，导向至[Polkadot.js Apps](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fwss.api.moonbase.moonbeam.network#/chainstate){target=_blank}**Developer**标签下的**Chain State**部分，并执行以下步骤：
+要获取所有基于Moonbeam网络主权账户和其对应索引操作的注册地址列表，导向至[Polkadot.js Apps](https://polkadot.js.org/apps/?rpc=wss://wss.api.moonbase.moonbeam.network#/chainstate){target=_blank}**Developer**标签下的**Chain State**部分，并执行以下步骤：
 
 1. 在**selected state query**下拉菜单中，选择**xcmTransactor**
 
@@ -189,7 +189,7 @@ XCM-Transactor Pallet包含以下只读函数以获取pallet常量：
 
 要在Polkadot.js Apps发送extrinsics，您需要准备以下内容：
 
- - 在原始链上的[账户](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fwss.api.moonbase.moonbeam.network#/accounts){target=_blank}拥有一定[资金](/builders/get-started/networks/moonbase/#get-tokens){target=_blank}
+ - 在原始链上的[账户](https://polkadot.js.org/apps/?rpc=wss://wss.api.moonbase.moonbeam.network#/accounts){target=_blank}拥有一定[资金](/builders/get-started/networks/moonbase/#get-tokens){target=_blank}
  - 资金所在的目标链上的multilocation衍生账户。您可以通过使用 [`calculateMultilocationDerivative.ts`脚本](https://github.com/albertov19/xcmTools/blob/main/calculateMultilocationDerivative.ts){target=_blank}计算该地址
 
 在本示例中，使用的账户如下：
@@ -199,7 +199,7 @@ XCM-Transactor Pallet包含以下只读函数以获取pallet常量：
 
 ### 构建XCM {: #xcm-transact-through-derivative }
 
-如果您已[完成准备工作](#xcmtransactor-signed-check-prerequisites)，导向至[Polkadot.js Apps](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fwss.api.moonbase.moonbeam.network#/extrinsics){target=_blank}的extrinsic页面，执行以下操作：
+如果您已[完成准备工作](#xcmtransactor-signed-check-prerequisites)，导向至[Polkadot.js Apps](https://polkadot.js.org/apps/?rpc=wss://wss.api.moonbase.moonbeam.network#/extrinsics){target=_blank}的extrinsic页面，执行以下操作：
 
 1. 选择您要发送XCM的账户，确保账户已[完成所有设置](#xcmtransactor-signed-check-prerequisites)
 2. 选择**xcmTransactor** pallet
@@ -216,7 +216,7 @@ XCM-Transactor Pallet包含以下只读函数以获取pallet常量：
     
 5. 设置**fee**类型。在本示例中，设置为**AsCurrencyId** 
 6. 将currency ID设置为**ForeignAsset**。请注意，该Token将从multilocation衍生账户提现来支付XCM执行费用。在这种情况下，将使用目标链的原生储备Token，但也可以是其他任何能够作为XCM执行支付费用的Token
-7. 输入asset ID。在本示例中，XC-20 Token的资产ID为`35487752324713722007834302681851459189`。您可以在Polkadot.js Apps的[资产部分](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fwss.api.moonbase.moonbeam.network#/assets){target=_blank}查看所有可用的资产ID
+7. 输入asset ID。在本示例中，XC-20 Token的资产ID为`35487752324713722007834302681851459189`。您可以在Polkadot.js Apps的[资产部分](https://polkadot.js.org/apps/?rpc=wss://wss.api.moonbase.moonbeam.network#/assets){target=_blank}查看所有可用的资产ID
 8. （可选）设置**feeAmount**。这是所选费用Token（XC-20）的每秒单位，将从multilocation衍生账户提取以支付XCM执行费用。在本示例中将每秒单位设置为`50000000000000000`。若您未提供此数值，pallet将使用存储库中的元素（若有）。请注意，存储中的元素可能不是最新的
 9. 输入将在目标链中执行的内部调用。这是pallet、方法和将被调用输入数值的编码调用数据。这可以在Polakdot.js Apps（必须连接至目标链）或使用[Polkadot.js API](/builders/build/substrate-api/polkadot-js-api/){target=_blank}构建。在本示例中，内部调用为`0x030044236223ab4291b93eed10e4b511b37a398dee5513000064a7b3b6e00d`（即将1 Token从目标链转移给Alice账户）
 10. 设置**weightInfo**结构的**transactRequiredWeightAtMost**权重值。该数值不包含XCM指令的权重。在本示例中，可以将权重设置为`1000000000`

--- a/builders/pallets-precompiles/precompiles/democracy.md
+++ b/builders/pallets-precompiles/precompiles/democracy.md
@@ -102,7 +102,7 @@ Moonbeam的链上治理系统得益于[Substrate民主pallet](https://docs.rs/pa
 
 ### 提交提案 {: #submit-a-proposal } 
 
-如果您拥有提案的哈希，您可以通过[民主预编译](https://github.com/PureStake/moonbeam/blob/master/precompiles/pallet-democracy/DemocracyInterface.sol){target=_blank}提交提案。如果您拥有带编码的提案，您同样可以通过预编译合约提交原像。为获得提案哈希和带编码的提案，导航到[Polkadot.JS Apps](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fmoonbeam-alpha.api.onfinality.io%2Fpublic-ws#/democracy){target=_blank}的**Democracy**标签，点击 **+ Submit preimage**, 然后进行以下操作：
+如果您拥有提案的哈希，您可以通过[民主预编译](https://github.com/PureStake/moonbeam/blob/master/precompiles/pallet-democracy/DemocracyInterface.sol){target=_blank}提交提案。如果您拥有带编码的提案，您同样可以通过预编译合约提交原像。为获得提案哈希和带编码的提案，导航到[Polkadot.JS Apps](https://polkadot.js.org/apps/?rpc=wss://wss.api.moonbase.moonbeam.network#/democracy){target=_blank}的**Democracy**标签，点击 **+ Submit preimage**, 然后进行以下操作：
 
  1. 选取一个账户（任何账户皆可，因为您不需要提交任何交易）
  2. 选取您希望交互的pallet以及可调度的函数（或是动作）以进行提案。您选取的动作将会决定您随后的操作步骤。在此例子中，此为**system** pallet和**remark**函数
@@ -132,7 +132,7 @@ Moonbeam的链上治理系统得益于[Substrate民主pallet](https://docs.rs/pa
 
 ![Call the propose function](/images/builders/pallets-precompiles/precompiles/democracy/democracy-8.png)
 
-在此步骤，您将会使用您在[Polkadot.JS Apps](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fmoonbeam-alpha.api.onfinality.io%2Fpublic-ws#/democracy){target=_blank}获得的带编码的提案，并通过民主预编译后中的`notePreimage`函数提交。尽管其名称，即原像（Preimage）并不需要在提案之前提交。然而，提交原像（Preimage）仍然需要在提案能够执行前进行提交。请跟随以下步骤通过**notePreimage**提交原像（Preimage）：
+在此步骤，您将会使用您在[Polkadot.JS Apps](https://polkadot.js.org/apps/?rpc=wss://wss.api.moonbase.moonbeam.network#/democracy){target=_blank}获得的带编码的提案，并通过民主预编译后中的`notePreimage`函数提交。尽管其名称，即原像（Preimage）并不需要在提案之前提交。然而，提交原像（Preimage）仍然需要在提案能够执行前进行提交。请跟随以下步骤通过**notePreimage**提交原像（Preimage）：
 
  1. 展开民主预编译合约以查看可用函数
  2. 找到**notePreimage**函数并点击按钮以展开区块
@@ -141,13 +141,13 @@ Moonbeam的链上治理系统得益于[Substrate民主pallet](https://docs.rs/pa
 
 ![Submit the preimage](/images/builders/pallets-precompiles/precompiles/democracy/democracy-7.png)
 
-在您交易确认后您可以回到[Polkadot.JS Apps](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fmoonbeam-alpha.api.onfinality.io%2Fpublic-ws#/democracy){target=_blank}的**Democracy**页面中确认您的提案是否在提案列表当中。
+在您交易确认后您可以回到[Polkadot.JS Apps](https://polkadot.js.org/apps/?rpc=wss://wss.api.moonbase.moonbeam.network#/democracy){target=_blank}的**Democracy**页面中确认您的提案是否在提案列表当中。
 
 ## 附议提案 {: #second-a-proposal } 
 
 附议提案将能够使其进入公投阶段，但需要绑定与先前提案者相同的Token数量。被附议的提案转移至公投需要一定时间，在Moonbase Alpha为{{ networks.moonbase.democracy.launch_period.days}}日，在Moonriver为{{ networks.moonbase.democracy.launch_period.days}}日，在Moonbeam为{{ networks.moonbeam.democracy.launch_period.days}}日。
 
-首先，您将需要获得您希望支持的提案的相关信息。当您在先前的步骤中提交提案，其将会有至少一个提案处于列表当中。您可以跟随以下步骤在[Polkadot.js Apps](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fmoonbeam-alpha.api.onfinality.io%2Fpublic-ws#/democracy){target=_blank}中获得提案的索引编码：
+首先，您将需要获得您希望支持的提案的相关信息。当您在先前的步骤中提交提案，其将会有至少一个提案处于列表当中。您可以跟随以下步骤在[Polkadot.js Apps](https://polkadot.js.org/apps/?rpc=wss://wss.api.moonbase.moonbeam.network#/democracy){target=_blank}中获得提案的索引编码：
 
 1. 导向至**Governance**标签
 2. 点击**Democracy**
@@ -165,7 +165,7 @@ Moonbeam的链上治理系统得益于[Substrate民主pallet](https://docs.rs/pa
 4. 虽然您要支持的提案编码已经记录如上，此时仍然需要参数上线。为避免出现gas预计错误，您需要输入明显大于附议数量的数字，在此例中输入的数字为`10` 
 5. 点击**transact**并在MetaMask确认此交易
 
-恭喜您已成功！如需查看您支持的提案，您可以返回[Polkadot.js Apps](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fmoonbeam-alpha.api.onfinality.io%2Fpublic-ws#/democracy){target=_blank}并查看您的账户是否出现在支持列表当中
+恭喜您已成功！如需查看您支持的提案，您可以返回[Polkadot.js Apps](https://polkadot.js.org/apps/?rpc=wss://wss.api.moonbase.moonbeam.network#/democracy){target=_blank}并查看您的账户是否出现在支持列表当中
 
 ![Second via the precompile](/images/builders/pallets-precompiles/precompiles/democracy/democracy-10.png)
 
@@ -176,7 +176,7 @@ Moonbeam的链上治理系统得益于[Substrate民主pallet](https://docs.rs/pa
 
 获得附议的提案转移至公投状态需要一定时间，在Moonbeam为{{ networks.moonbeam.democracy.launch_period.days}}日，在Moonriver为{{ networks.moonriver.democracy.launch_period.days}}，在Moonbase为{{ networks.moonbase.democracy.launch_period.days}}。如果在Moonbase Alpha中没有正在进行中的公投，您可能需要等待启用阶段以度过您支持提案的转移时间，方能进入公投阶段。
 
-首先，如果您希望进行投票，您需要获得公投的编码。记住，提案编码与公投编码两者不同。您可以跟随以下步骤在[Polkadot.js Apps](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fmoonbeam-alpha.api.onfinality.io%2Fpublic-ws#/democracy){target=_blank}上获得公投编码：
+首先，如果您希望进行投票，您需要获得公投的编码。记住，提案编码与公投编码两者不同。您可以跟随以下步骤在[Polkadot.js Apps](https://polkadot.js.org/apps/?rpc=wss://wss.api.moonbase.moonbeam.network#/democracy){target=_blank}上获得公投编码：
 
 1. 导向至**Governance**标签
 2. 点击**Democracy**

--- a/builders/pallets-precompiles/precompiles/staking.md
+++ b/builders/pallets-precompiles/precompiles/staking.md
@@ -219,7 +219,7 @@ Solidity接口包含以下的函数：
 
 ### 验证委托 {: #verify-delegation }
 
-您可以在Polkadot.js Apps查看链状态以验证您的委托是否成功。首先，将MetaMask地址加入[Polkadot.js Apps地址簿](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fwss.api.moonbase.moonbeam.network#/addresses){target=_blank}。
+您可以在Polkadot.js Apps查看链状态以验证您的委托是否成功。首先，将MetaMask地址加入[Polkadot.js Apps地址簿](https://polkadot.js.org/apps/?rpc=wss://wss.api.moonbase.moonbeam.network#/addresses){target=_blank}。
 
 导航至**Accounts**，选择**Address Book**，点击**Add contact**，输入以下信息：
 
@@ -229,7 +229,7 @@ Solidity接口包含以下的函数：
 
 ![Add to Address Book](/images/builders/pallets-precompiles/precompiles/staking/staking-8.png)
 
-要验证您的委托是否成功，请前往[Polkadot.js 应用程序](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fwss.api.moonbase.moonbeam.network#/chainstate){target=_blank}并导航到**Developer**然后点击**Chain State**
+要验证您的委托是否成功，请前往[Polkadot.js 应用程序](https://polkadot.js.org/apps/?rpc=wss://wss.api.moonbase.moonbeam.network#/chainstate){target=_blank}并导航到**Developer**然后点击**Chain State**
 
 1. 选择**parachainStaking** Pallet
 2. 选择**delegatorState**查询

--- a/node-operators/networks/collators/activities.md
+++ b/node-operators/networks/collators/activities.md
@@ -53,7 +53,7 @@ description: 关于深入了解并学习成为Moonbeam网络中收集人相关�
 
 ### 获取候选人池的大小 {: #get-the-size-of-the-candidate-pool } 
 
-首先，您需要获取`candidatePool`的大小（可通过治理更改），该参数将用于后续交易中。为此，您必须从[Polkadot.js](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fwss.api.moonbase.moonbeam.network#/js){target=_blank}中运行以下JavaScript代码段：
+首先，您需要获取`candidatePool`的大小（可通过治理更改），该参数将用于后续交易中。为此，您必须从[Polkadot.js](https://polkadot.js.org/apps/?rpc=wss://wss.api.moonbase.moonbeam.network#/js){target=_blank}中运行以下JavaScript代码段：
 
 ```js
 // Simple script to get candidate pool size
@@ -75,7 +75,7 @@ console.log(`Candidate pool size is: ${candidatePool.length}`);
 
 ### 加入候选人池 {: #join-the-candidate-pool } 
 
-节点开始运行并同步网络后，您将成为候选人（并加入候选人池）。根据您所连接的网络，前往[Polkadot.js](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fwss.api.moonbase.moonbeam.network#/accounts){target=_blank}，点击**Developer**标签，从下拉菜单中选择**JavaScript**，然后进行以下步骤：
+节点开始运行并同步网络后，您将成为候选人（并加入候选人池）。根据您所连接的网络，前往[Polkadot.js](https://polkadot.js.org/apps/?rpc=wss://wss.api.moonbase.moonbeam.network#/accounts){target=_blank}，点击**Developer**标签，从下拉菜单中选择**JavaScript**，然后进行以下步骤：
 
   1. 选择您想用于参与收集活动的账户。确认您的收集人账户已充值[所需的最低质押量](/node-operators/networks/collators/requirements/#minimum-collator-bond){target=_blank}，并有多余金额用于支付交易费
   2. 在**submit the following extrinsic**菜单中选择**parachainStaking** pallet
@@ -184,7 +184,7 @@ console.log(`Candidate pool size is: ${candidatePool.length}`);
 
 ### 增加自身绑定数量 {: #bond-more }
 
-作为候选人，有两种增加质押量的选择。第一个，也是我们所推荐的选项是将要质押的资金发送到另一个您所拥有的地址，并[委托您的收集人](/tokens/staking/stake/#how-to-nominate-a-collator)。第二个，已经拥有[最低自身绑定数量](/node-operators/networks/collators/requirements/#minimum-collator-bond){target=_blank}的收集人可以通过[Polkadot JS Apps](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fwss.api.moonriver.moonbeam.network#/accounts)增加其绑定数量。导向至**Developer**标签，点击**Extrinsics**，并进行以下步骤：
+作为候选人，有两种增加质押量的选择。第一个，也是我们所推荐的选项是将要质押的资金发送到另一个您所拥有的地址，并[委托您的收集人](/tokens/staking/stake/#how-to-nominate-a-collator)。第二个，已经拥有[最低自身绑定数量](/node-operators/networks/collators/requirements/#minimum-collator-bond){target=_blank}的收集人可以通过[Polkadot JS Apps](https://polkadot.js.org/apps/?rpc=wss://wss.api.moonriver.moonbeam.network#/accounts)增加其绑定数量。导向至**Developer**标签，点击**Extrinsics**，并进行以下步骤：
 
   1. 选择您的收集人账户（并验证该账户是否有足够资金可用于绑定）
   2. 在**submit the following extrinsic**菜单中选择**parachainStaking** pallet

--- a/tokens/manage/identity.md
+++ b/tokens/manage/identity.md
@@ -45,7 +45,7 @@ description: 学习如何在基于Moonbeam的网络上创建和清除身份，�
 
 使用本指南将需要以下几个先决条件：
 
-- 您需要在PolkadotJS App浏览器上连接至[Moonbase Alpha测试网](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fwss.api.moonbase.moonbeam.network){target=_blank}。此教程也适用于[Moonbeam](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fwss.api.moonbeam.network){target=_blank}和[Moonriver](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fwss.api.moonriver.moonbeam.network){target=_blank}
+- 您需要在PolkadotJS App浏览器上连接至[Moonbase Alpha测试网](https://polkadot.js.org/apps/?rpc=wss://wss.api.moonbase.moonbeam.network){target=_blank}。此教程也适用于[Moonbeam](https://polkadot.js.org/apps/?rpc=wss://wss.api.moonbeam.network){target=_blank}和[Moonriver](https://polkadot.js.org/apps/?rpc=wss://wss.api.moonriver.moonbeam.network){target=_blank}
 - 同时，您也需要在PolkadotJS Apps创建或是导入一个账户。如果您尚未创建或导入账户，请跟随以下教程来[创建或导入一个H160账户](/tokens/connect/polkadotjs/#creating-or-importing-an-h160-account){target=_blank}
 - 请确认账户中有足够资金。
  --8<-- 'text/faucet/faucet-list-item.md'
@@ -60,7 +60,7 @@ description: 学习如何在基于Moonbeam的网络上创建和清除身份，�
 
 ### 设置身份 {: #set-an-identity }
 
-如果想开始使用账户UI设置一个身份，请导向至PolkadotJS Apps浏览器的[Accounts标签](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fwss.api.moonbase.moonbeam.network#/accounts){target=_blank}页面。
+如果想开始使用账户UI设置一个身份，请导向至PolkadotJS Apps浏览器的[Accounts标签](https://polkadot.js.org/apps/?rpc=wss://wss.api.moonbase.moonbeam.network#/accounts){target=_blank}页面。
 
 您应该已经有一个已连接网络的账户，所以您可以点击您的账户名称以确认实时的账户余额。在设置身份并传送交易之后，您提交的款项将会从您的可转账余额转移至您的储蓄账户。
 
@@ -98,7 +98,7 @@ description: 学习如何在基于Moonbeam的网络上创建和清除身份，�
 
 ### 清除身份 {: #clear-an-identity }
 
-如果您想从PolkadotJS Apps界面的[Accounts标签](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fwss.api.moonbase.moonbeam.network#/accounts){target=_blank}中清除您的身份，您可以跟随以下步骤：
+如果您想从PolkadotJS Apps界面的[Accounts标签](https://polkadot.js.org/apps/?rpc=wss://wss.api.moonbase.moonbeam.network#/accounts){target=_blank}中清除您的身份，您可以跟随以下步骤：
 
 1. 点击您希望清除身份信息账户旁的三个垂直点按钮
 
@@ -120,7 +120,7 @@ description: 学习如何在基于Moonbeam的网络上创建和清除身份，�
 
 ### 设置身份 {: #set-an-identity }
 
-如果您想要使用Extrinsic UI注册一个身份，请导向PolkadotJS Apps的[Extrinsics页面](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fwss.api.moonbase.moonbeam.network#/extrinsics){target=_blank}。接着，您可以跟随以下步骤操作：
+如果您想要使用Extrinsic UI注册一个身份，请导向PolkadotJS Apps的[Extrinsics页面](https://polkadot.js.org/apps/?rpc=wss://wss.api.moonbase.moonbeam.network#/extrinsics){target=_blank}。接着，您可以跟随以下步骤操作：
 
 1. 选取您的账户
 
@@ -164,7 +164,7 @@ description: 学习如何在基于Moonbeam的网络上创建和清除身份，�
 
 ### 确认身份 {: #confirm-an-identity }
 
-如果您想重新确认您的身份信息，您可以导向至**开发者**标签并进入[Chain state](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fwss.api.moonbase.moonbeam.network#/chainstate){target=_blank}页面。
+如果您想重新确认您的身份信息，您可以导向至**开发者**标签并进入[Chain state](https://polkadot.js.org/apps/?rpc=wss://wss.api.moonbase.moonbeam.network#/chainstate){target=_blank}页面。
 
 在**Chain State**的界面，请确认已选取**Storage**选项。接着您可以开始查询您的身份信息：
 
@@ -182,7 +182,7 @@ description: 学习如何在基于Moonbeam的网络上创建和清除身份，�
 
 ### 清除身份 {: #clear-an-identity }
 
-如果您想从PolkadotJS Apps界面的[Extrinsics标签](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fwss.api.moonbase.moonbeam.network#/extrinsics){target=_blank}中清除您的身份，您可以跟随以下步骤：
+如果您想从PolkadotJS Apps界面的[Extrinsics标签](https://polkadot.js.org/apps/?rpc=wss://wss.api.moonbase.moonbeam.network#/extrinsics){target=_blank}中清除您的身份，您可以跟随以下步骤：
 
 1. 在**using the selected account**下拉选单中选取您的账户
 

--- a/tokens/manage/proxy-accounts.md
+++ b/tokens/manage/proxy-accounts.md
@@ -19,7 +19,7 @@ description: 了解如何在基于Moonbeam的网络上设置代理帐户，以�
 
 在操作本教程之前，您需要准备：
 
-- 打开[Polkadot.js Apps](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fwss.testnet.moonbeam.network#/explorer)并已连接至Moonbase Alpha
+- 打开[Polkadot.js Apps](https://polkadot.js.org/apps/?rpc=wss://wss.api.moonbase.moonbeam.network#/explorer)并已连接至Moonbase Alpha
 - 在Moonbase Alpha上创建或拥有2个账户
 - 至少有一个账户拥有`DEV` Token
 --8<-- 'text/faucet/faucet-list-item.md'

--- a/tokens/staking/stake.md
+++ b/tokens/staking/stake.md
@@ -55,7 +55,7 @@ Token持有者可以向候选人质押自己的Token，这一过程称为委托�
 
 您可以使用Polkadot.js Apps查看任何常量质押数值，例如最大委托数量、最低质押要求、委托请求的退出延迟等。
 
-为此，您可以导航至Polkadot.js Apps的**Chain State**界面，本教程会连接至[Moonbase Alpha](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fwss.api.moonbase.moonbeam.network#/chainstate){target=_blank}，但也可以链接至[Moonbeam](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fwss.api.moonbeam.network/#chainstate){target=_blank}或是[Moonriver](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fwss.api.moonriver.moonbeam.network/#chainstate){target=_blank}。
+为此，您可以导航至Polkadot.js Apps的**Chain State**界面，本教程会连接至[Moonbase Alpha](https://polkadot.js.org/apps/?rpc=wss://wss.api.moonbase.moonbeam.network#/chainstate){target=_blank}，但也可以链接至[Moonbeam](https://polkadot.js.org/apps/?rpc=wss://wss.api.moonbeam.network/#chainstate){target=_blank}或是[Moonriver](https://polkadot.js.org/apps/?rpc=wss://wss.api.moonriver.moonbeam.network/#chainstate){target=_blank}。
 
 接着，为了检索各种质押参数，请在**Chain State**界面选取**Constants**标签，并执行以下步骤：
 
@@ -103,7 +103,7 @@ Token持有者可以向候选人质押自己的Token，这一过程称为委托�
 
 ### 获取候选人自动复合委托数量 {: #get-candidate-auto-compounding-count }
 
-自动复合委托计数是配置了自动复合的委托数量。要确定设置了自动复合的委托数量，您可以在[Polkadot.js Apps](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fwss.api.moonbase.moonbeam.network#/js){target=_blank}上使用以下代码段查询候选人的自动复合委托：
+自动复合委托计数是配置了自动复合的委托数量。要确定设置了自动复合的委托数量，您可以在[Polkadot.js Apps](https://polkadot.js.org/apps/?rpc=wss://wss.api.moonbase.moonbeam.network#/js){target=_blank}上使用以下代码段查询候选人的自动复合委托：
 
 ```js
 // Simple script to get the number of auto-compounding delegations for a given candidate.
@@ -124,7 +124,7 @@ console.log(autoCompoundingDelegations.toHuman().length);
 
 ### 获取目前委托数据 {: #get-your-number-of-existing-delegations }
 
-如果您从来没有从这个账户进行委托，您可以跳过这步。但是如果您不确定您目前有多少个委托，您可以从[Polkadot.js](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fwss.api.moonbase.moonbeam.network#/js){target=_blank}运行以下的Javascript代码段来获取`delegationCount`：
+如果您从来没有从这个账户进行委托，您可以跳过这步。但是如果您不确定您目前有多少个委托，您可以从[Polkadot.js](https://polkadot.js.org/apps/?rpc=wss://wss.api.moonbase.moonbeam.network#/js){target=_blank}运行以下的Javascript代码段来获取`delegationCount`：
 
 ```js
 // Simple script to get your number of existing delegations.


### PR DESCRIPTION
### Description/Original PRs

Update links to Polkadot.js Apps. There were a few still using the onfinality endpoint and there were a bunch that had `rpc=wss%3A%2F%2Fwss` in the link, so I updated them to be cleaner and use `rpc=wss://wss`
