### PR TITLE
minor fix

### DIFF
--- a/builders/build/eth-api/libraries/ethersjs.md
+++ b/builders/build/eth-api/libraries/ethersjs.md
@@ -479,7 +479,7 @@ const increment = async () => {
   );
 
   // 7. Sign and send tx and wait for receipt
-  const createReceipt = await incrementer.increment([_value]);
+  const createReceipt = await incrementer.increment(_value);
   await createReceipt.wait();
 
   console.log(`Tx successful with hash: ${createReceipt.hash}`);


### PR DESCRIPTION
### Description/Original PRs

The `incrementer.increment` value in the ethers guide shouldn't be an array - the value should be passed in as a number. The test suite already uses a number as the value (https://github.com/PureStake/moonbeam-docs-test-suite/blob/main/test/builders/build/eth-api/libraries/ethers/deploy-contract.js#L134)
